### PR TITLE
Fix macOS menu availability across modes

### DIFF
--- a/src-app/src/app/bootstrap.rs
+++ b/src-app/src/app/bootstrap.rs
@@ -1087,6 +1087,88 @@ pub(crate) fn install_macos_menu_bar(cx: &mut gpui::App) {
     ]);
 }
 
+/// Register macOS menu actions as app-global fallbacks.
+///
+/// AppKit validates menu items via GPUI's `is_action_available`, which checks
+/// the focused dispatch path plus app-global listeners. PaneFlow's normal
+/// handlers live on the rendered root element so keyboard/menu dispatch works
+/// while that root is in the focused path, but macOS can validate the native
+/// menu while focus sits in a terminal/Agents surface whose current rendered
+/// path does not expose the root listeners. These fallbacks make the native
+/// menu items consistently enabled and mirror the root handlers when they are
+/// otherwise unreachable.
+#[cfg(target_os = "macos")]
+pub(crate) fn install_macos_menu_action_fallbacks(cx: &mut gpui::App) {
+    use crate::{
+        About, CloseWorkspace, Copy, NewWorkspace, NextWorkspace, OpenHelp, PaneFlowApp, Paste,
+        Quit, SelectAll, TerminalCopy, TerminalPaste,
+    };
+
+    fn with_active_paneflow_window(
+        cx: &mut gpui::App,
+        f: impl FnOnce(&mut PaneFlowApp, &mut gpui::Window, &mut Context<PaneFlowApp>),
+    ) {
+        let Some(window) = cx.active_window() else {
+            return;
+        };
+        let Some(window) = window.downcast::<PaneFlowApp>() else {
+            return;
+        };
+        if let Err(err) = window.update(cx, f) {
+            log::debug!("macOS menu fallback: active PaneFlow window unavailable: {err}");
+        }
+    }
+
+    cx.on_action(|_: &Quit, cx| {
+        with_active_paneflow_window(cx, |app, _window, cx| {
+            app.save_session_blocking(cx);
+            app.emit_app_exited_and_flush();
+            cx.quit();
+        });
+    });
+
+    cx.on_action(|_: &About, cx| {
+        with_active_paneflow_window(cx, |app, _window, cx| {
+            app.show_about_dialog = true;
+            cx.notify();
+        });
+    });
+
+    cx.on_action(|_: &Copy, cx| cx.dispatch_action(&TerminalCopy));
+    cx.on_action(|_: &Paste, cx| cx.dispatch_action(&TerminalPaste));
+    cx.on_action(|_: &SelectAll, _cx| {
+        log::debug!("Edit > Select All dispatched (terminal select-all not yet wired)");
+    });
+
+    cx.on_action(|_: &NewWorkspace, cx| {
+        with_active_paneflow_window(cx, |app, window, cx| {
+            app.create_workspace_with_picker(window, cx);
+        });
+    });
+    cx.on_action(|_: &CloseWorkspace, cx| {
+        with_active_paneflow_window(cx, |app, window, cx| {
+            app.close_workspace_at(app.active_idx, window, cx);
+        });
+    });
+    cx.on_action(|_: &NextWorkspace, cx| {
+        with_active_paneflow_window(cx, |app, window, cx| {
+            if !app.workspaces.is_empty() {
+                let next = (app.active_idx + 1) % app.workspaces.len();
+                app.select_workspace(next, window, cx);
+            }
+        });
+    });
+
+    cx.on_action(|_: &OpenHelp, cx| {
+        with_active_paneflow_window(cx, |app, _window, cx| {
+            if let Err(e) = open::that("https://github.com/ArthurDEV44/paneflow#readme") {
+                log::warn!("Help > PaneFlow Help: could not open browser: {e}");
+                app.show_toast(format!("Could not open help: {e}"), cx);
+            }
+        });
+    });
+}
+
 /// Detect whether the Apple Silicon binary is running under Rosetta 2
 /// translation on an Intel Mac (or, more commonly, an Intel binary on
 /// Apple Silicon - which Apple translates transparently). Either way it

--- a/src-app/src/main.rs
+++ b/src-app/src/main.rs
@@ -96,7 +96,9 @@ pub(crate) use app::notifications::{Toast, ToastAction};
 // Free helpers extracted to bootstrap.rs but still callable as
 // `crate::system_package_update_command` etc. from sibling modules.
 #[cfg(target_os = "macos")]
-pub(crate) use app::bootstrap::{install_macos_menu_bar, warn_if_rosetta_translated};
+pub(crate) use app::bootstrap::{
+    install_macos_menu_action_fallbacks, install_macos_menu_bar, warn_if_rosetta_translated,
+};
 pub(crate) use app::bootstrap::{system_package_update_command, warn_if_legacy_run_install};
 
 // Terminal-routing helpers (`find_first_terminal`, `find_terminal_by_surface_id`)
@@ -1098,20 +1100,20 @@ impl Render for PaneFlowApp {
                     cx.quit();
                 }),
             )
-            // US-012: macOS menu-bar actions. `Quit` mirrors `CloseWindow`.
-            // `About` is a placeholder; clicking it logs until we ship a
-            // real About surface. `Copy` / `Paste` delegate to the existing
-            // terminal clipboard actions so Edit > Copy works when a
-            // terminal pane is focused (matches the ⌘C keybinding from
-            // US-010). `SelectAll` is a no-op until the terminal exposes
-            // a select-all action.
+            // US-012: macOS menu-bar actions. `Quit` mirrors `CloseWindow`;
+            // `About` opens the in-app About dialog. `Copy` / `Paste`
+            // delegate to the existing terminal clipboard actions so Edit >
+            // Copy works when a terminal pane is focused (matches the ⌘C
+            // keybinding from US-010). `SelectAll` is a no-op until the
+            // terminal exposes a select-all action.
             .on_action(cx.listener(|this: &mut Self, _: &Quit, _window, cx| {
                 this.save_session_blocking(cx);
                 this.emit_app_exited_and_flush();
                 cx.quit();
             }))
-            .on_action(cx.listener(|_this: &mut Self, _: &About, _window, _cx| {
-                log::info!("About PaneFlow: v{}", env!("CARGO_PKG_VERSION"));
+            .on_action(cx.listener(|this: &mut Self, _: &About, _window, cx| {
+                this.show_about_dialog = true;
+                cx.notify();
             }))
             .on_action(cx.listener(|_this: &mut Self, _: &Copy, _window, cx| {
                 cx.dispatch_action(&TerminalCopy);
@@ -2050,7 +2052,10 @@ fn main() {
             // elided - GPUI's non-macOS platforms don't render a menu bar
             // and AC5 forbids any Linux UI change.
             #[cfg(target_os = "macos")]
-            install_macos_menu_bar(cx);
+            {
+                install_macos_menu_bar(cx);
+                install_macos_menu_action_fallbacks(cx);
+            }
 
             let bounds = Bounds::centered(None, size(px(1200.0), px(800.0)), cx);
             let decorations = match config.window_decorations.as_deref() {


### PR DESCRIPTION
Refs #11

## Summary

- Install app-global macOS menu action fallbacks so GPUI/AppKit validation sees PaneFlow menu actions even when focus is inside CLI or Agents surfaces.
- Wire those fallbacks next to the existing native macOS menu bar install.
- Make the root `About` action open the existing About dialog instead of only logging.

## Root Cause

GPUI validates native macOS menu items with `cx.is_action_available`, which depends on the active window focus dispatch path plus app-global action listeners. PaneFlow had the native menu bar installed, but the app-global fallbacks were not registered, so Settings could validate through its focused settings surface while CLI/Agents focus could leave system menu actions unavailable.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p paneflow-app`
- `cargo clippy -p paneflow-app -- -D warnings`

The `aarch64-apple-darwin` check was attempted but could not complete in the Windows environment because no `cc`/`clang` compiler is available for the `psm` build script before PaneFlow itself is checked.

## Manual macOS Checks

- In Settings, verify About/Quit and File/Help menu items remain enabled and functional.
- In CLI/terminal and Agents views, verify those same native menu items no longer appear disabled.
- Verify `About PaneFlow` opens the app About dialog and Help opens the README.
- Verify titlebar File/Help popovers still accept clicks in CLI/Agents views.