### PR TITLE
fix(release): sign Windows executable before MSI packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -912,7 +912,7 @@ jobs:
              && [ -n "${AZURE_TRUSTED_SIGNING_ENDPOINT:-}" ] \
              && [ -n "${AZURE_TRUSTED_SIGNING_ACCOUNT:-}" ] \
              && [ -n "${AZURE_TRUSTED_SIGNING_CERT_PROFILE:-}" ]; then
-              echo "All 6 Azure Trusted Signing secrets are present - will produce + sign + verify MSI."
+              echo "All 6 Azure Trusted Signing secrets are present - will sign the EXE, then produce + sign + verify MSI."
               echo "signing_available=true" >> "$GITHUB_OUTPUT"
           else
               echo "::warning title=Windows MSI packaging skipped::One or more AZURE_* secrets are missing - skipping Preflight WiX / Install cargo-wix / Produce MSI / Sign / Verify / Stage. Build/test/clippy still run for cross-platform validation. See docs/release/windows-signing.md to enable."
@@ -972,6 +972,28 @@ jobs:
         if: runner.os == 'Windows' && steps.windows_signing.outputs.signing_available == 'true'
         run: cargo install cargo-wix --version 0.3.9 --locked
 
+      # ─── Windows Authenticode: sign the installed executable first ───────
+      # Smart App Control evaluates the installed application binary, not just
+      # the container MSI. WiX embeds this exact release binary, so sign it
+      # before `cargo wix --no-build` packages it into Program Files.
+      - name: Sign Windows executable
+        id: sign_windows_exe
+        if: runner.os == 'Windows' && steps.windows_signing.outputs.signing_available == 'true'
+        shell: pwsh
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          AZURE_TRUSTED_SIGNING_ACCOUNT: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT }}
+          AZURE_TRUSTED_SIGNING_CERT_PROFILE: ${{ secrets.AZURE_TRUSTED_SIGNING_CERT_PROFILE }}
+        run: |
+          $exe = 'target\x86_64-pc-windows-msvc\release\paneflow.exe'
+          if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) {
+              throw "No Windows release executable found at $exe. The Build release binary step may have failed or emitted an unexpected path."
+          }
+          pwsh -NoProfile -File ./scripts/sign-windows.ps1 -InputFile $exe
+
       # ─── US-016 AC-1: Produce MSI ────────────────────────────────────────
       # cargo-wix reads [package.metadata.wix] in src-app/Cargo.toml (US-013)
       # and `packaging/wix/main.wxs` to drive candle → light. The
@@ -980,7 +1002,7 @@ jobs:
       # ProductVersion schema rejects `v0.1.7` and accepts only `0.1.7`.
       #
       # Output: `target/wix/paneflow-<ver>-x86_64.msi`. The `--target`
-      # flag tells cargo-wix which release binary to pick up
+      # flag tells cargo-wix which already-signed release binary to pick up
       # (`target/x86_64-pc-windows-msvc/release/paneflow.exe`) but the
       # installer output directory is always `target/wix/` regardless -
       # do NOT assume the triple folder.

--- a/docs/release/windows-signing.md
+++ b/docs/release/windows-signing.md
@@ -1,11 +1,11 @@
 # Windows code signing runbook (US-024)
 
 One-time setup, secret rotation, and ACME auto-renewal tracking for the
-PaneFlow Windows release pipeline. The `release.yml` workflow signs every
-`x86_64-pc-windows-msvc` `.msi` produced by `cargo wix build` when the six
-`AZURE_*` GitHub Secrets are populated. If any secret is missing the leg
-degrades to an **unsigned** build with a banner in the job summary - by
-design (US-024 AC-5).
+PaneFlow Windows release pipeline. When the six `AZURE_*` GitHub Secrets are
+populated, `release.yml` signs the `x86_64-pc-windows-msvc` `paneflow.exe`
+before WiX packages it, then signs the final `.msi` produced by `cargo wix`.
+If any secret is missing the leg degrades to an **unsigned** build with a
+banner in the job summary - by design (US-024 AC-5).
 
 This document is operator-only. Application code never reads from any of
 the secrets described here.
@@ -14,15 +14,20 @@ the secrets described here.
 
 ## 1. What gets signed
 
-`cargo wix build` (driven by `[package.metadata.wix]` in
-`src-app/Cargo.toml` and `packaging/wix/main.wxs`) produces a single
-artifact:
+The Windows leg signs two artifacts in order:
+
+1. `target/x86_64-pc-windows-msvc/release/paneflow.exe` after the release
+   build and before WiX packaging. This is the binary installed to
+   `%ProgramFiles%\PaneFlow\paneflow.exe`, and Smart App Control evaluates it
+   directly when users launch the app.
+2. `target/wix/paneflow-<version>-x86_64.msi` after `cargo wix` packages the
+   signed executable into the installer.
 
 ```
 target/wix/paneflow-<version>-x86_64.msi
 ```
 
-`scripts/sign-windows.ps1` then:
+`scripts/sign-windows.ps1` is used for both the `.exe` and the `.msi`. It:
 
 1. **Fetches the Microsoft.ArtifactSigning.Client NuGet** (pinned to
    `1.0.128`) into a per-invocation temp directory and resolves
@@ -116,13 +121,16 @@ change.
    > `CertificateProfileName`). Keep the longer name when populating the
    > secret.
 6. **Dry-run on a test tag.** Push `vX.Y.Z-rc1`, watch the Windows leg in
-   `release.yml`. The `Verify MSI signature` step must emit the literal
+   `release.yml`. The `Sign Windows executable` step must complete before
+   `Produce MSI`, and the `Verify MSI signature` step must emit the literal
    string `Successfully verified` - that is AC-6. Download the resulting
    `paneflow-X.Y.Z-x86_64-pc-windows-msvc.msi` artifact and on a clean
-   Windows 11 VM confirm the SmartScreen prompt shows `Strivex` (not
-   "Unknown Publisher"). New publishers build SmartScreen reputation
-   over ~3,000 unique downloads or 6-8 weeks; an initial "Unknown
-   Publisher" prompt is expected and not a signing failure.
+   Windows 11 VM confirm both the installed
+   `%ProgramFiles%\PaneFlow\paneflow.exe` and the MSI report a valid
+   Authenticode signature for `O=Strivex`. New publishers build SmartScreen
+   reputation over ~3,000 unique downloads or 6-8 weeks; an initial
+   reputation prompt can still happen, but "publisher could not be verified"
+   on the installed EXE means the executable was not signed before packaging.
 
 ## 4. Secret rotation
 
@@ -160,6 +168,7 @@ This is the principal reason Azure Trusted Signing was chosen over a
 | **Cert profile deleted** | `CertificateProfile not found`. | Recreate the profile with the same name (`PaneFlow-Release`) in Azure Portal → Trusted Signing. The next sign picks up a fresh leaf via ACME. |
 | **Azure subscription suspended / billing issue** | Sign step fails immediately (`continue-on-error` absorbs it). Linux + macOS ship without a Windows asset. | Resolve billing in Azure Portal → Cost Management. Re-run via `workflow_dispatch`. |
 | **SmartScreen still flags "Unknown Publisher" after onboarding** | Users report SmartScreen warning even on signed builds. | Reputation builds over time. Per Microsoft, trust propagates after ~3,000 unique verified downloads OR within 6-8 weeks of consistent signing. **No action needed** - expected for the first month of a new publisher identity. |
+| **Smart App Control blocks `%ProgramFiles%\PaneFlow\paneflow.exe` with "publisher could not be verified"** | The MSI may be signed, but the installed EXE is unsigned or was signed after WiX packaged it. | Check the `Sign Windows executable` step ran before `Produce MSI`. Re-run the release workflow and verify `Get-AuthenticodeSignature 'C:\Program Files\PaneFlow\paneflow.exe'` returns `Valid` on a clean VM. |
 | **Runner image dropped Windows SDK** | `signtool.exe not found`. | Add an explicit `microsoft/setup-msbuild@v2` or Windows 11 SDK install step to the Windows leg, mirroring the `Preflight WiX v3 toolchain` pattern. Pin the SDK version. |
 
 ## 6. OV-cert fallback (decoupled - local script ready)
@@ -188,6 +197,8 @@ Wiring CI for OV is a fork of the Sign MSI step that swaps
 # GitHub Secret if/when CI wiring is added.
 $env:OV_CERT_PATH = 'C:\path\to\paneflow-ov.p12'
 $env:OV_CERT_PASSWORD = '<password from password manager>'
+pwsh -NoProfile -File scripts/sign-windows-ov.ps1 `
+    -InputFile target/x86_64-pc-windows-msvc/release/paneflow.exe
 pwsh -NoProfile -File scripts/sign-windows-ov.ps1 `
     -InputFile target/wix/paneflow-X.Y.Z-x86_64.msi
 ```
@@ -223,6 +234,15 @@ The output must contain:
 
 Alternatively, right-click the `.msi` → Properties → Digital Signatures.
 The "Name of signer" should display `Strivex`.
+
+Operator check after installing the MSI:
+
+```powershell
+Get-AuthenticodeSignature 'C:\Program Files\PaneFlow\paneflow.exe' |
+    Format-List Status,StatusMessage,SignerCertificate
+```
+
+`Status` must be `Valid`, and the signer subject must anchor to `O=Strivex`.
 
 ## 8. Hardening backlog (post-US-024 follow-ups)
 

--- a/scripts/sign-windows-ov.ps1
+++ b/scripts/sign-windows-ov.ps1
@@ -1,8 +1,8 @@
 <#
 .SYNOPSIS
-    Sign a PaneFlow MSI with an OV (Organization Validation) code-signing
-    certificate. **Local-only** fallback for the Azure Trusted Signing
-    path implemented by sign-windows.ps1.
+    Sign a PaneFlow Windows artifact with an OV (Organization Validation)
+    code-signing certificate. **Local-only** fallback for the Azure Trusted
+    Signing path implemented by sign-windows.ps1.
 
 .DESCRIPTION
     US-024 AC-4. If Azure Trusted Signing becomes unavailable
@@ -20,7 +20,7 @@
     after the OV cert itself expires.
 
 .PARAMETER InputFile
-    Path to the .msi to sign. Required.
+    Path to the .exe or .msi artifact to sign. Required.
 
 .PARAMETER CertPath
     Path to the OV cert in PKCS#12 format. Defaults to $env:OV_CERT_PATH.
@@ -37,6 +37,11 @@
     $env:OV_CERT_PATH = 'C:\paneflow-ov.p12'
     $env:OV_CERT_PASSWORD = '<from-password-manager>'
     scripts\sign-windows-ov.ps1 -InputFile .\target\wix\paneflow-0.3.0-x86_64.msi
+
+.EXAMPLE
+    $env:OV_CERT_PATH = 'C:\paneflow-ov.p12'
+    $env:OV_CERT_PASSWORD = '<from-password-manager>'
+    scripts\sign-windows-ov.ps1 -InputFile .\target\x86_64-pc-windows-msvc\release\paneflow.exe
 
 .NOTES
     See docs/release/windows-signing.md §"OV-cert fallback" for the
@@ -80,9 +85,10 @@ if (-not (Test-Path -LiteralPath $InputFile -PathType Leaf)) {
 }
 
 $resolvedInput = (Resolve-Path -LiteralPath $InputFile).Path
+$inputExtension = [System.IO.Path]::GetExtension($resolvedInput).ToLowerInvariant()
 
-if ([System.IO.Path]::GetExtension($resolvedInput).ToLowerInvariant() -ne '.msi') {
-    throw "InputFile must be an .msi artifact: $resolvedInput"
+if ($inputExtension -notin @('.exe', '.msi')) {
+    throw "InputFile must be a .exe or .msi artifact: $resolvedInput"
 }
 
 # --- Validate cert + password --------------------------------------------

--- a/scripts/sign-windows.ps1
+++ b/scripts/sign-windows.ps1
@@ -1,13 +1,12 @@
 <#
 .SYNOPSIS
-    Sign a PaneFlow MSI with Azure Artifact Signing (formerly Trusted Signing).
+    Sign a PaneFlow Windows artifact with Azure Artifact Signing (formerly Trusted Signing).
 
 .DESCRIPTION
     US-015. Wraps `signtool.exe sign` with the Azure dlib + a generated
     metadata.json so CI can invoke it uniformly per artifact. Run on a
-    windows-2022 GitHub-hosted runner AFTER `cargo wix build` has produced
-    the MSI (US-016). The signed MSI is then picked up by the Stage Windows
-    assets step and uploaded as a release asset.
+    windows-2022 GitHub-hosted runner for both the release executable before
+    WiX packaging and the final MSI after `cargo wix` has produced it.
 
     The Azure dlib and signtool authenticate silently via DefaultAzureCredential
     narrowed to EnvironmentCredential (other credential types are excluded via
@@ -15,7 +14,7 @@
     managed-identity probes on runners that don't have one.
 
 .PARAMETER InputFile
-    Path to the .msi to sign. Required.
+    Path to the .exe or .msi artifact to sign. Required.
 
 .PARAMETER DlibPath
     Optional override for the path to Azure.CodeSigning.Dlib.dll. When omitted
@@ -28,6 +27,9 @@
 
 .EXAMPLE
     scripts\sign-windows.ps1 -InputFile .\target\wix\paneflow-0.1.0-x86_64.msi
+
+.EXAMPLE
+    scripts\sign-windows.ps1 -InputFile .\target\x86_64-pc-windows-msvc\release\paneflow.exe
 
 .NOTES
     Required env vars (provisioned via GitHub Secrets per US-014):
@@ -65,9 +67,10 @@ if (-not (Test-Path -LiteralPath $InputFile -PathType Leaf)) {
 }
 
 $resolvedInput = (Resolve-Path -LiteralPath $InputFile).Path
+$inputExtension = [System.IO.Path]::GetExtension($resolvedInput).ToLowerInvariant()
 
-if ([System.IO.Path]::GetExtension($resolvedInput).ToLowerInvariant() -ne '.msi') {
-    Write-Error "InputFile must be an .msi artifact: $resolvedInput"
+if ($inputExtension -notin @('.exe', '.msi')) {
+    Write-Error "InputFile must be a .exe or .msi artifact: $resolvedInput"
     exit 1
 }
 


### PR DESCRIPTION
## Summary

- Sign `target/x86_64-pc-windows-msvc/release/paneflow.exe` before WiX packages it into the Windows MSI.
- Keep signing the final MSI after packaging.
- Allow both Azure and OV signing scripts to sign `.exe` and `.msi` artifacts.
- Update the Windows signing runbook with the Smart App Control failure mode and verification command.

## Root Cause

The Windows release pipeline signed the MSI container, but Smart App Control evaluates the installed app binary at `C:\Program Files\PaneFlow\paneflow.exe`. If the EXE was unsigned when WiX packaged it, users could still see “publisher could not be verified” despite a signed installer.

## Validation

- `ctx7` lookup against Microsoft Azure docs for Artifact Signing + SignTool integration.
- `git diff --cached --check`
- PowerShell parser check for `scripts/sign-windows.ps1` and `scripts/sign-windows-ov.ps1`
- YAML parse for `.github/workflows/release.yml`
- `cargo fmt --check`