### PR TITLE
feat(app): add Rosetta agent status surface

### DIFF
--- a/crates/paneflow-config/src/loader.rs
+++ b/crates/paneflow-config/src/loader.rs
@@ -889,6 +889,8 @@ mod tests {
             claude_code_bypass_permissions: None,
             ai_unrestricted: None,
             ai_injection_fence: None,
+            rosetta_enabled: None,
+            rosetta_show_passive: None,
             claude_code_button_visible: None,
             codex_button_visible: None,
             opencode_button_visible: None,

--- a/crates/paneflow-config/src/schema.rs
+++ b/crates/paneflow-config/src/schema.rs
@@ -141,6 +141,17 @@ pub struct PaneFlowConfig {
     /// non-boolean value resolves to `None` (fence ON) with a warn.
     #[serde(default, deserialize_with = "lenient_opt_bool")]
     pub ai_injection_fence: Option<bool>,
+    /// EP-004 US-013 (Rosetta): master switch for the in-app Rosetta card.
+    /// `Some(false)` disables only Rosetta; sidebar dots, Attention Queue and
+    /// OS notifications keep their existing behavior. Missing or malformed
+    /// values resolve to ON so urgent agent states stay visible after upgrade.
+    #[serde(default, deserialize_with = "lenient_opt_bool")]
+    pub rosetta_enabled: Option<bool>,
+    /// EP-004 US-013 (Rosetta): whether passive running-only rows may show the
+    /// compact card. `None` resolves to false so a fresh config is urgent-only;
+    /// users can turn it on when they want passive running summaries.
+    #[serde(default, deserialize_with = "lenient_opt_bool")]
+    pub rosetta_show_passive: Option<bool>,
     /// Show the built-in "Claude Code" command button in the tab bar.
     /// `Some(true)` always renders the button, `Some(false)` hides it, and
     /// `None` (default) renders it only when the CLI binary is installed.
@@ -352,17 +363,27 @@ impl PaneFlowConfig {
     pub fn ai_injection_fence_enabled(&self) -> bool {
         self.ai_injection_fence.unwrap_or(true)
     }
+
+    /// EP-004 US-013 (Rosetta): resolve the master switch. Default ON so
+    /// upgrading users get urgent Rosetta states without editing config.
+    pub fn rosetta_enabled(&self) -> bool {
+        self.rosetta_enabled.unwrap_or(true)
+    }
+
+    /// EP-004 US-013 (Rosetta): resolve passive display. Default OFF keeps
+    /// Rosetta urgent-only on a fresh config; setting true restores the compact
+    /// running-only card from US-004.
+    pub fn rosetta_show_passive_enabled(&self) -> bool {
+        self.rosetta_show_passive.unwrap_or(false)
+    }
 }
 
 /// Lenient `Option<bool>` deserializer for the security-sensitive AI-access
-/// toggles (`ai_unrestricted`, `ai_injection_fence`). A non-boolean value
-/// (e.g. the string `"true"`) deserializes to `None` with a `warn!` instead
-/// of hard-erroring, which would propagate to `parse_and_validate` and wipe
-/// EVERY sibling setting on a single typo (the all-or-nothing fallback the
-/// terminal enums avoid for the same reason). `None` then resolves to each
-/// field's safe default via its resolver (`ai_unrestricted` -> false,
-/// `ai_injection_fence` -> true), so a malformed value can never accidentally
-/// open the free-access mode nor disable the fence (US-008 AC #3).
+/// and Rosetta toggles. A non-boolean value (e.g. the string `"true"`)
+/// deserializes to `None` with a `warn!` instead of hard-erroring, which would
+/// propagate to `parse_and_validate` and wipe EVERY sibling setting on a single
+/// typo (the all-or-nothing fallback the terminal enums avoid for the same
+/// reason). `None` then resolves through each field's resolver.
 fn lenient_opt_bool<'de, D>(d: D) -> Result<Option<bool>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -375,7 +396,7 @@ where
             tracing::warn!(
                 target: "paneflow_config",
                 value = %other,
-                "expected a boolean for an AI-access toggle, ignoring (using safe default)",
+                "expected a boolean config toggle, ignoring value and using resolver default",
             );
             None
         }
@@ -1407,6 +1428,8 @@ mod tests {
             claude_code_bypass_permissions: Some(false),
             ai_unrestricted: Some(true),
             ai_injection_fence: Some(false),
+            rosetta_enabled: Some(true),
+            rosetta_show_passive: Some(false),
             claude_code_button_visible: Some(true),
             codex_button_visible: Some(true),
             opencode_button_visible: Some(true),
@@ -1638,6 +1661,27 @@ mod tests {
             Some("One Dark"),
             "siblings survive a malformed AI-access toggle"
         );
+    }
+
+    #[test]
+    fn rosetta_settings_resolve_defaults_and_tolerate_garbage() {
+        let cfg = PaneFlowConfig::default();
+        assert!(cfg.rosetta_enabled());
+        assert!(!cfg.rosetta_show_passive_enabled());
+
+        let cfg: PaneFlowConfig =
+            serde_json::from_str(r#"{"rosetta_enabled": false, "rosetta_show_passive": false}"#)
+                .unwrap();
+        assert!(!cfg.rosetta_enabled());
+        assert!(!cfg.rosetta_show_passive_enabled());
+
+        let cfg: PaneFlowConfig = serde_json::from_str(
+            r#"{"theme": "One Dark", "rosetta_enabled": "no", "rosetta_show_passive": 0}"#,
+        )
+        .unwrap();
+        assert!(cfg.rosetta_enabled());
+        assert!(!cfg.rosetta_show_passive_enabled());
+        assert_eq!(cfg.theme.as_deref(), Some("One Dark"));
     }
 
     #[test]

--- a/crates/paneflow-shim/src/hooks.rs
+++ b/crates/paneflow-shim/src/hooks.rs
@@ -1352,13 +1352,19 @@ fn is_paneflow_plugin_entry(value: &serde_json::Value) -> bool {
 // Grok (`~/.grok/hooks/paneflow.json` - dedicated merged hook file)
 // ---------------------------------------------------------------------------
 
-/// Grok Build hook events - PascalCase, Claude-compatible names. Same
-/// reduced set as Qoder: `Notification` is skipped (Grok's stdin payload
-/// has no `notification_type`, so the hook's whitelist would drop every
-/// frame) and `SessionStart`/`SessionEnd` are covered by the shim's
-/// universal lifecycle.
-pub(crate) const GROK_HOOK_EVENTS: &[&str] =
-    &["UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop"];
+/// Grok Build hook events - PascalCase, Claude-compatible names.
+/// `Notification` is skipped (Grok's stdin payload has no
+/// `notification_type`, so the hook's whitelist would drop every frame);
+/// approval prompts use `PermissionRequest`, which `paneflow-ai-hook`
+/// normalizes to `notification_type: "permission_prompt"`.
+/// `SessionStart`/`SessionEnd` are covered by the shim's universal lifecycle.
+pub(crate) const GROK_HOOK_EVENTS: &[&str] = &[
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PostToolUse",
+    "PermissionRequest",
+    "Stop",
+];
 
 /// RAII guard for Grok: writes a DEDICATED `~/.grok/hooks/paneflow.json`
 /// (Grok merges every `*.json` in that dir at discovery - global hooks are

--- a/crates/paneflow-shim/src/main.rs
+++ b/crates/paneflow-shim/src/main.rs
@@ -1090,12 +1090,14 @@ mod tests {
         let path = hooks_dir.join("paneflow.json");
         let root: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        // Claude matcher-group shape, reduced event set.
+        // Claude matcher-group shape, reduced event set with explicit
+        // permission requests.
         assert!(root["hooks"]["UserPromptSubmit"].is_array());
+        assert!(root["hooks"]["PermissionRequest"].is_array());
         assert!(root["hooks"]["Stop"].is_array());
         assert!(
             root["hooks"].get("Notification").is_none(),
-            "Notification must not be registered for Grok (whitelist-dropped)"
+            "Notification must not be registered for Grok; PermissionRequest handles approvals"
         );
         let cmd = root["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
             .as_str()

--- a/docs/rosetta-qa-runbook.md
+++ b/docs/rosetta-qa-runbook.md
@@ -1,0 +1,95 @@
+# Rosetta QA runbook
+
+Use this checklist for Rosetta changes before moving a story past `IN_REVIEW`.
+
+## Automated gates
+
+Run from the repository root:
+
+```powershell
+cargo fmt --check
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+```
+
+For focused iteration:
+
+```powershell
+cargo test -p paneflow-app app::rosetta -- --nocapture
+cargo test -p paneflow-config rosetta -- --nocapture
+```
+
+## Manual matrix
+
+Record each target as `pass`, `fail`, or `not verified`, with date and OS.
+
+| Target | Result | Notes |
+| --- | --- | --- |
+| Windows 10 or 11 x64 | not verified | |
+| macOS Apple Silicon | not verified | |
+| macOS Intel | not verified | |
+| Linux X11 | not verified | |
+| Linux Wayland | not verified | |
+
+Do not infer Linux Wayland coverage from X11, and do not infer Windows ARM64
+coverage from x64.
+
+## Scenarios
+
+1. CLI mode, waiting agent:
+   - Start Paneflow in CLI mode.
+   - Create or simulate one `WaitingForInput` agent session with a live pane.
+   - Confirm Rosetta appears top-center in the main content area, not in the
+     sidebar or titlebar.
+   - Click the row or press `Enter` in the expanded panel.
+   - Confirm focus lands on the original workspace pane.
+
+2. Agents mode thread:
+   - Open Agents mode with one running or waiting terminal thread.
+   - Confirm Rosetta includes the thread title and project/chat context.
+   - Activate the row.
+   - Confirm Paneflow stays in Agents mode and selects the correct thread.
+
+3. Expanded keyboard behavior:
+   - Open Rosetta expanded with at least three rows.
+   - Press `Down` and `Up`.
+   - Confirm selection moves one row at a time without terminal input leaking.
+   - Press `Enter` on a navigable row.
+   - Confirm the selected target focuses.
+   - Reopen Rosetta, press `Esc`, and confirm it collapses with focus restored
+     to the prior terminal or thread.
+
+4. Narrow width:
+   - Resize to 900 px wide or below.
+   - Confirm the compact card stays within viewport minus 32 px.
+   - Confirm long workspace/thread names and messages truncate without overlap.
+
+5. Closed target fallback:
+   - Open Rosetta expanded on a navigable row.
+   - Close the target pane or thread before activating the row.
+   - Press `Enter`.
+   - Confirm there is no panic and Rosetta reports `Target unavailable` or
+     `No pane`, without focusing an unrelated target.
+
+6. Untrusted text:
+   - Use an agent message containing Markdown, ANSI color escapes, URL-like
+     text, bidi/zero-width controls, and button-looking copy.
+   - Confirm Rosetta displays inert plain text only.
+   - Confirm no `Approve` or `Deny` control appears unless typed action
+     metadata is complete and internally generated.
+
+7. Settings:
+   - In Settings -> AI Agent -> Rosetta, disable Rosetta.
+   - Confirm the card disappears while sidebar status, Attention Queue, and OS
+     notification behavior are unchanged.
+   - Re-enable Rosetta and toggle `Show running agents`.
+   - Restart Paneflow and confirm the choices persisted.
+   - Put invalid values in `paneflow.json` for `rosetta_enabled` or
+     `rosetta_show_passive`.
+   - Confirm the app does not panic and falls back through the config resolver.
+
+8. Diff/Review surface:
+   - Switch to Diff mode.
+   - Confirm Rosetta is gated off there for v1. Rosetta currently supports CLI
+     and Agents mode only; the PRD Review-mode question remains documented
+     until a distinct Review app mode exists.

--- a/schemas/paneflow.schema.json
+++ b/schemas/paneflow.schema.json
@@ -178,6 +178,16 @@
       "description": "Anti-injection fence on the surface.read CLI/IPC path, independent of ai_unrestricted. Null/true (default) wraps returned terminal text in an <untrusted_terminal_output> marker so a malicious peer pane cannot hijack a conductor reading it. False returns raw text (an assumed risk). Stays ON by default even in free-access mode because the fence protects the AI, it does not bridle it.",
       "default": true
     },
+    "rosetta_enabled": {
+      "type": ["boolean", "null"],
+      "description": "Master switch for the in-app Rosetta card. Null/true (default) enables Rosetta for supported modes; false hides only Rosetta while sidebar, Attention Queue, and OS notifications continue unchanged.",
+      "default": true
+    },
+    "rosetta_show_passive": {
+      "type": ["boolean", "null"],
+      "description": "Show compact Rosetta rows when all rows are passive running agents. Null/false (default) keeps Rosetta urgent-only until waiting, failed, stalled, or recent rows exist; true enables passive running summaries.",
+      "default": false
+    },
     "claude_code_button_visible": {
       "type": ["boolean", "null"],
       "description": "Show the built-in 'Claude Code' command button. Null/omitted auto-detects the CLI binary.",

--- a/src-app/src/agents/notifications.rs
+++ b/src-app/src/agents/notifications.rs
@@ -9,6 +9,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use gpui::BackgroundExecutor;
 use paneflow_config::schema::{AgentPanelConfig, NotifyWhenAgentWaiting, PaneFlowConfig};
 
+use crate::agent_launcher::TerminalAgent;
+
+const NOTIFICATION_DETAIL_CAP_CHARS: usize = 512;
+
 /// Stable Windows AppUserModelID. The WiX Start Menu shortcut mirrors this in
 /// `packaging/wix/main.wxs`; the dev/unpackaged path also registers it under
 /// HKCU\Software\Classes\AppUserModelId before showing a toast.
@@ -56,33 +60,45 @@ pub(crate) struct DesktopNotification {
 }
 
 impl DesktopNotification {
-    pub(crate) fn turn_finished(workspace_title: &str) -> Self {
+    pub(crate) fn turn_finished(
+        agent: TerminalAgent,
+        workspace_title: &str,
+        session_summary: Option<&str>,
+    ) -> Self {
         Self {
-            summary: "Agent finished".to_string(),
-            body: format!("{workspace_title} is ready."),
+            summary: format!("{} finished", agent.display_name()),
+            body: notification_context_body(workspace_title, session_summary),
             urgency: DesktopNotificationUrgency::Normal,
         }
     }
 
-    pub(crate) fn needs_input(workspace_title: &str, message: Option<&str>) -> Self {
+    pub(crate) fn needs_input(
+        agent: TerminalAgent,
+        workspace_title: &str,
+        message: Option<&str>,
+    ) -> Self {
         Self {
-            summary: "Paneflow needs your input".to_string(),
+            summary: format!("{} needs input", agent.display_name()),
             body: attention_notification_body(workspace_title, message),
             urgency: DesktopNotificationUrgency::Critical,
         }
     }
 
-    pub(crate) fn agent_exited(workspace_title: &str, exit_code: i32) -> Self {
+    pub(crate) fn agent_exited(
+        agent: TerminalAgent,
+        workspace_title: &str,
+        exit_code: i32,
+    ) -> Self {
         Self {
-            summary: "Agent exited unexpectedly".to_string(),
+            summary: format!("{} exited unexpectedly", agent.display_name()),
             body: agent_exit_notification_body(workspace_title, exit_code),
             urgency: DesktopNotificationUrgency::Critical,
         }
     }
 
-    pub(crate) fn stalled(workspace_title: &str, silent_secs: u64) -> Self {
+    pub(crate) fn stalled(agent: TerminalAgent, workspace_title: &str, silent_secs: u64) -> Self {
         Self {
-            summary: "Agent may be stuck".to_string(),
+            summary: format!("{} may be stuck", agent.display_name()),
             body: stalled_notification_body(workspace_title, silent_secs),
             urgency: DesktopNotificationUrgency::Critical,
         }
@@ -130,19 +146,41 @@ pub(crate) fn sanitize_notification_message(raw: &str) -> String {
     crate::markdown::strip_bidi_zero_width(raw.chars().take(512).collect())
 }
 
+fn notification_detail(raw: &str) -> Option<String> {
+    let clean: String = crate::markdown::strip_bidi_zero_width(
+        raw.chars().take(NOTIFICATION_DETAIL_CAP_CHARS).collect(),
+    )
+    .trim()
+    .to_string();
+    (!clean.is_empty()).then_some(clean)
+}
+
+pub(crate) fn notification_context_body(
+    workspace_title: &str,
+    session_summary: Option<&str>,
+) -> String {
+    session_summary
+        .and_then(notification_detail)
+        .or_else(|| notification_detail(workspace_title))
+        .unwrap_or_else(|| "Paneflow".to_string())
+}
+
 pub(crate) fn attention_notification_body(workspace_title: &str, message: Option<&str>) -> String {
-    match message.filter(|m| !m.trim().is_empty()) {
-        Some(m) => format!("{workspace_title}: {m}"),
-        None => format!("{workspace_title}: approval needed"),
-    }
+    notification_context_body(workspace_title, message)
 }
 
 pub(crate) fn agent_exit_notification_body(workspace_title: &str, exit_code: i32) -> String {
-    format!("{workspace_title}: agent exited with code {exit_code}")
+    format!(
+        "{}: exited with code {exit_code}",
+        notification_context_body(workspace_title, None)
+    )
 }
 
 pub(crate) fn stalled_notification_body(workspace_title: &str, silent_secs: u64) -> String {
-    format!("{workspace_title}: no agent activity for {silent_secs} s")
+    format!(
+        "{}: no activity for {silent_secs} s",
+        notification_context_body(workspace_title, None)
+    )
 }
 
 fn show_desktop_notification(notification: DesktopNotification) -> Result<(), String> {
@@ -278,36 +316,47 @@ mod tests {
     fn notification_bodies_are_specific_and_non_empty() {
         assert_eq!(
             attention_notification_body("backend", Some("Allow `cargo test`?")),
-            "backend: Allow `cargo test`?"
+            "Allow `cargo test`?"
         );
-        assert_eq!(
-            attention_notification_body("backend", None),
-            "backend: approval needed"
-        );
+        assert_eq!(attention_notification_body("backend", None), "backend");
         assert_eq!(
             attention_notification_body("backend", Some("   ")),
-            "backend: approval needed"
+            "backend"
         );
         assert_eq!(
             agent_exit_notification_body("api", 1),
-            "api: agent exited with code 1"
+            "api: exited with code 1"
         );
         assert_eq!(
             stalled_notification_body("api", 300),
-            "api: no agent activity for 300 s"
+            "api: no activity for 300 s"
+        );
+        assert_eq!(
+            notification_context_body("workspace", Some("Finished the release draft")),
+            "Finished the release draft"
         );
     }
 
     #[test]
     fn desktop_notification_constructors_set_title_body_and_urgency() {
-        let finished = DesktopNotification::turn_finished("backend");
-        assert_eq!(finished.summary, "Agent finished");
-        assert_eq!(finished.body, "backend is ready.");
+        let finished =
+            DesktopNotification::turn_finished(TerminalAgent::Codex, "backend", Some("Tests pass"));
+        assert_eq!(finished.summary, "Codex finished");
+        assert_eq!(finished.body, "Tests pass");
         assert_eq!(finished.urgency, DesktopNotificationUrgency::Normal);
 
-        let attention = DesktopNotification::needs_input("backend", Some("Approve edit?"));
-        assert_eq!(attention.summary, "Paneflow needs your input");
-        assert_eq!(attention.body, "backend: Approve edit?");
+        let finished_without_summary =
+            DesktopNotification::turn_finished(TerminalAgent::Codex, "backend", None);
+        assert_eq!(finished_without_summary.summary, "Codex finished");
+        assert_eq!(finished_without_summary.body, "backend");
+
+        let attention = DesktopNotification::needs_input(
+            TerminalAgent::ClaudeCode,
+            "backend",
+            Some("Approve edit?"),
+        );
+        assert_eq!(attention.summary, "Claude Code needs input");
+        assert_eq!(attention.body, "Approve edit?");
         assert_eq!(attention.urgency, DesktopNotificationUrgency::Critical);
     }
 }

--- a/src-app/src/app/actions.rs
+++ b/src-app/src/app/actions.rs
@@ -147,6 +147,7 @@ actions!(
         // cross-workspace with its question + wait time; `OpenLaunchPad`
         // (US-005) is the worktree + split + agent + prefill one-gesture
         // modal.
+        ToggleRosettaSurface,
         OpenAttentionQueue,
         OpenLaunchPad
     ]

--- a/src-app/src/app/bootstrap.rs
+++ b/src-app/src/app/bootstrap.rs
@@ -744,6 +744,10 @@ impl PaneFlowApp {
         cx.observe(&settings_search_input, |_, _, cx| cx.notify())
             .detach();
 
+        let cached_config = paneflow_config::loader::load_config();
+        let effective_shortcuts = keybindings::effective_shortcuts(&cached_config.shortcuts);
+        let rosetta_passive_display_enabled = cached_config.rosetta_show_passive_enabled();
+
         let mut app = Self {
             workspaces,
             active_idx,
@@ -752,7 +756,7 @@ impl PaneFlowApp {
             pending_config,
             save_seq: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
             // US-014: hydrate the render-path config cache once at startup.
-            cached_config: paneflow_config::loader::load_config(),
+            cached_config,
             ipc_rx,
             ipc_status,
             event_bus,
@@ -782,9 +786,7 @@ impl PaneFlowApp {
                 .map(|p| p.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             sidebar_scroll: gpui::ScrollHandle::new(),
-            effective_shortcuts: keybindings::effective_shortcuts(
-                &paneflow_config::loader::load_config().shortcuts,
-            ),
+            effective_shortcuts,
             recording_shortcut_idx: None,
             settings_focus: cx.focus_handle(),
             mono_font_names: Vec::new(),
@@ -848,6 +850,17 @@ impl PaneFlowApp {
             attention_queue_open: false,
             attention_queue_selected: 0,
             attention_queue_focus: cx.focus_handle(),
+            rosetta_recent_history: crate::app::rosetta::RosettaRecentHistory::default(),
+            rosetta_surface_expanded: false,
+            rosetta_surface_selected: 0,
+            rosetta_surface_selected_key: None,
+            rosetta_surface_focus: cx.focus_handle(),
+            rosetta_surface_scroll: gpui::ScrollHandle::new(),
+            rosetta_surface_pending_focus: false,
+            rosetta_snoozed_rows: std::collections::HashMap::new(),
+            rosetta_dismissed_rows: std::collections::HashSet::new(),
+            rosetta_read_rows: std::collections::HashSet::new(),
+            rosetta_passive_display_enabled,
             // EP-006 US-018 (cli-cockpit): fleet grep closed.
             fleet_search: None,
             fleet_search_generation: 0,

--- a/src-app/src/app/event_handlers.rs
+++ b/src-app/src/app/event_handlers.rs
@@ -377,6 +377,36 @@ impl PaneFlowApp {
                     self.agents_view.sidebar_mode_picker_open = false;
                 }
             }
+            title_bar::TitleBarEvent::ToggleRosettaSurface => {
+                self.title_bar_files_menu_open = None;
+                self.title_bar_help_menu_open = None;
+                self.workspace_menu_open = None;
+                self.tab_menu_open = None;
+                self.profile_menu_open = None;
+                self.files_menu_open = None;
+                self.agents_view.agents_menu_open = None;
+                self.agents_view.sidebar_actions_menu_open = false;
+                self.agents_view.sidebar_mode_picker_open = false;
+
+                if self.rosetta_surface_expanded {
+                    self.rosetta_surface_expanded = false;
+                    self.rosetta_surface_selected = 0;
+                    self.rosetta_surface_selected_key = None;
+                    self.rosetta_surface_pending_focus = false;
+                } else {
+                    let projection = self.rosetta_projection(std::time::Instant::now());
+                    self.rosetta_surface_expanded = true;
+                    self.rosetta_surface_selected = self
+                        .rosetta_surface_selected
+                        .min(projection.rows.len().saturating_sub(1));
+                    self.rosetta_surface_selected_key = projection
+                        .rows
+                        .get(self.rosetta_surface_selected)
+                        .map(crate::app::rosetta::RosettaRow::key);
+                    self.rosetta_surface_pending_focus = true;
+                }
+                cx.notify();
+            }
             title_bar::TitleBarEvent::ToggleFilesMenu(anchor) => {
                 self.title_bar_files_menu_open =
                     self.title_bar_files_menu_open.is_none().then_some(*anchor);
@@ -1062,7 +1092,8 @@ impl PaneFlowApp {
         } else {
             None
         };
-        let mut stalled_notifs: Vec<(String, u64, bool)> = Vec::new();
+        let mut stalled_notifs: Vec<(crate::agent_launcher::TerminalAgent, String, u64, bool)> =
+            Vec::new();
         for ws in &mut self.workspaces {
             if ws.agent_sessions.is_empty() {
                 continue;
@@ -1100,6 +1131,7 @@ impl PaneFlowApp {
                         // clear defensively rather than rely on that.
                         session.waiting_since = None;
                         stalled_notifs.push((
+                            session.tool,
                             ws.title.clone(),
                             session.last_activity.elapsed().as_secs(),
                             active_workspace_id == Some(ws.id),
@@ -1143,8 +1175,9 @@ impl PaneFlowApp {
         // EP-004 US-011: fire AFTER the state writes so the notification and
         // the UI agree. One entry per Thinking→Stalled transition == one
         // notification per stall episode (PRD dedup AC).
-        for (title, silent_secs, source_visible) in stalled_notifs {
+        for (agent, title, silent_secs, source_visible) in stalled_notifs {
             super::ipc_handler::fire_stalled_notification(
+                agent,
                 &title,
                 silent_secs,
                 &self.cached_config,

--- a/src-app/src/app/ipc_handler.rs
+++ b/src-app/src/app/ipc_handler.rs
@@ -17,8 +17,8 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::Duration;
 
-use gpui::{App, AppContext, Context, Entity, Focusable};
-use paneflow_config::schema::{AppMode, LayoutNode, TerminalSurfaceProfile};
+use gpui::{App, AppContext, BackgroundExecutor, Context, Entity, Focusable};
+use paneflow_config::schema::{AppMode, LayoutNode, PaneFlowConfig, TerminalSurfaceProfile};
 
 use crate::agent_launcher::TerminalAgent;
 use crate::agents::notifications::{self as desktop_notifications, DesktopNotification};
@@ -56,6 +56,14 @@ const UP_PREFILL_POLL: Duration = Duration::from_millis(200);
 const UP_LAUNCH_FLOOR: Duration = Duration::from_millis(700);
 const UP_LAUNCH_MAX: Duration = Duration::from_millis(4000);
 const UP_LAUNCH_POLL: Duration = Duration::from_millis(100);
+
+struct TranscriptTurnEndNotification {
+    agent: TerminalAgent,
+    title: String,
+    config: PaneFlowConfig,
+    source_visible: bool,
+    executor: BackgroundExecutor,
+}
 
 /// EP-001 US-001 (agent-control-plane-hardening): cadence at which the deferred
 /// submit polls a freshly-pasted agent's `output_generation` for the paste echo
@@ -124,13 +132,15 @@ fn build_up_layout(preset: &str, panes: Vec<Entity<Pane>>, focus_idx: usize) -> 
 }
 
 fn fire_turn_end_notification(
+    agent: TerminalAgent,
     workspace_title: &str,
+    session_summary: Option<&str>,
     config: &paneflow_config::schema::PaneFlowConfig,
     source_visible: bool,
     executor: gpui::BackgroundExecutor,
 ) {
     desktop_notifications::fire_desktop_notification(
-        DesktopNotification::turn_finished(workspace_title),
+        DesktopNotification::turn_finished(agent, workspace_title, session_summary),
         config,
         source_visible,
         executor,
@@ -138,6 +148,7 @@ fn fire_turn_end_notification(
 }
 
 fn fire_attention_notification(
+    agent: TerminalAgent,
     workspace_title: &str,
     message: Option<&str>,
     config: &paneflow_config::schema::PaneFlowConfig,
@@ -145,7 +156,7 @@ fn fire_attention_notification(
     executor: gpui::BackgroundExecutor,
 ) {
     desktop_notifications::fire_desktop_notification(
-        DesktopNotification::needs_input(workspace_title, message),
+        DesktopNotification::needs_input(agent, workspace_title, message),
         config,
         source_visible,
         executor,
@@ -177,6 +188,15 @@ fn read_last_result(params: &serde_json::Value) -> Option<String> {
     Some(crate::markdown::strip_bidi_zero_width(
         raw.chars().take(2048).collect(),
     ))
+}
+
+fn read_notification_message(params: &serde_json::Value) -> Option<String> {
+    let hook = params.get("hook_payload");
+    hook.and_then(|h| h.get("message"))
+        .and_then(|v| v.as_str())
+        .or_else(|| params.get("message").and_then(|v| v.as_str()))
+        .map(sanitize_notification_message)
+        .filter(|message| !message.trim().is_empty())
 }
 
 /// EP-004 US-010 (agent-control-plane-hardening): a Stop-hook transcript larger
@@ -219,6 +239,15 @@ fn read_transcript_path(params: &serde_json::Value) -> Option<std::path::PathBuf
 /// Pure (path in, text out) so it is unit-tested against a fixture file.
 fn extract_last_result_from_transcript(path: &std::path::Path) -> Option<String> {
     extract_last_result_capped(path, TRANSCRIPT_READ_CAP)
+}
+
+fn read_stop_summary(params: &serde_json::Value) -> (Option<String>, Option<std::path::PathBuf>) {
+    let inline = read_last_result(params);
+    let transcript_path = inline
+        .is_none()
+        .then(|| read_transcript_path(params))
+        .flatten();
+    (inline, transcript_path)
 }
 
 /// Inner with an explicit cap so the oversize-skip branch is unit-testable
@@ -428,6 +457,7 @@ fn stage_context_file(
 }
 
 fn fire_agent_exit_notification(
+    agent: TerminalAgent,
     workspace_title: &str,
     exit_code: i32,
     config: &paneflow_config::schema::PaneFlowConfig,
@@ -435,7 +465,7 @@ fn fire_agent_exit_notification(
     executor: gpui::BackgroundExecutor,
 ) {
     desktop_notifications::fire_desktop_notification(
-        DesktopNotification::agent_exited(workspace_title, exit_code),
+        DesktopNotification::agent_exited(agent, workspace_title, exit_code),
         config,
         source_visible,
         executor,
@@ -448,6 +478,7 @@ fn fire_agent_exit_notification(
 /// structural (the sweep only flips `Thinking`, so a stalled session can't
 /// re-trigger until a hook event revives it first).
 pub(crate) fn fire_stalled_notification(
+    agent: TerminalAgent,
     workspace_title: &str,
     silent_secs: u64,
     config: &paneflow_config::schema::PaneFlowConfig,
@@ -455,7 +486,7 @@ pub(crate) fn fire_stalled_notification(
     executor: gpui::BackgroundExecutor,
 ) {
     desktop_notifications::fire_desktop_notification(
-        DesktopNotification::stalled(workspace_title, silent_secs),
+        DesktopNotification::stalled(agent, workspace_title, silent_secs),
         config,
         source_visible,
         executor,
@@ -1171,6 +1202,7 @@ impl PaneFlowApp {
             // pick up the reload without a per-frame `load_config()`. Last use
             // of `config` - move it in.
             self.cached_config = config;
+            self.sync_rosetta_config_state();
             // US-015: push the refreshed config to every pane's tab-bar cache.
             for ws in &self.workspaces {
                 ws.propagate_config(&self.cached_config, cx);
@@ -1713,24 +1745,32 @@ impl PaneFlowApp {
     }
 
     /// EP-004 US-010 (agent-control-plane-hardening): read a Claude Code Stop-hook
-    /// transcript OFF the render thread and backfill the session's `last_result`
-    /// with the last assistant message. The `ai.stop` handler runs on the GPUI
-    /// thread, so the file read goes through `smol::unblock`; the result is
-    /// deposited back via `cx.update`. Best-effort: any miss leaves `last_result`
-    /// null (the conductor falls back to the US-009 file discipline). Keyed on
-    /// `(ws_id, session_key)` like the auto-clear timer, and only fills when the
-    /// slot is STILL empty, so a newer turn's inline summary is never clobbered.
-    fn schedule_transcript_read(
-        ws_id: u64,
-        session_key: u32,
+    /// transcript OFF the render thread, optionally backfill `last_result`, and
+    /// optionally fire the turn-end notification with the extracted summary.
+    /// Best-effort: any miss keeps the workspace/thread title fallback.
+    fn schedule_transcript_turn_end(
+        update_target: Option<(u64, u32)>,
         path: std::path::PathBuf,
+        notification: Option<TranscriptTurnEndNotification>,
         cx: &mut Context<Self>,
     ) {
         cx.spawn(
             async move |this: gpui::WeakEntity<Self>, cx: &mut gpui::AsyncApp| {
                 let extracted =
                     smol::unblock(move || extract_last_result_from_transcript(&path)).await;
-                let Some(text) = extracted else {
+                if let Some(notification) = notification {
+                    desktop_notifications::fire_desktop_notification(
+                        DesktopNotification::turn_finished(
+                            notification.agent,
+                            &notification.title,
+                            extracted.as_deref(),
+                        ),
+                        &notification.config,
+                        notification.source_visible,
+                        notification.executor,
+                    );
+                }
+                let (Some((ws_id, session_key)), Some(text)) = (update_target, extracted) else {
                     return;
                 };
                 cx.update(|cx| {
@@ -2856,7 +2896,6 @@ impl PaneFlowApp {
                 let Some(workspace_id) = params.get("workspace_id").and_then(|v| v.as_u64()) else {
                     return serde_json::json!({"error": "Missing workspace_id"});
                 };
-                let hook = params.get("hook_payload");
                 let pid = read_session_pid(params);
                 let Some(tool) = read_tool(params) else {
                     // An unknown binary name can't map to a TerminalAgent -
@@ -2865,12 +2904,7 @@ impl PaneFlowApp {
                     return serde_json::json!({"error": "Unknown tool"});
                 };
                 let explicit_surface_id = self.validated_frame_surface_id(params, cx);
-                let message = sanitize_notification_message(
-                    hook.and_then(|h| h.get("message"))
-                        .and_then(|v| v.as_str())
-                        .or_else(|| params.get("message").and_then(|v| v.as_str()))
-                        .unwrap_or("Needs input"),
-                );
+                let message = read_notification_message(params);
                 let notify_config = self.cached_config.clone();
                 let active_workspace_id = self.workspaces.get(self.active_idx).map(|ws| ws.id);
                 let workspace_source_visible =
@@ -2889,13 +2923,14 @@ impl PaneFlowApp {
                     // and the desktop notification surface it. Untrusted
                     // text: stored and displayed verbatim, never interpreted.
                     if let Some(s) = ws.agent_sessions.get_mut(&key) {
-                        s.message = Some(message.clone());
+                        s.message = message.clone();
                     }
                     let ws_title = ws.title.clone();
                     cx.notify();
                     fire_attention_notification(
+                        tool,
                         &ws_title,
-                        Some(&message),
+                        message.as_deref(),
                         &notify_config,
                         workspace_source_visible,
                         cx.background_executor().clone(),
@@ -2921,8 +2956,9 @@ impl PaneFlowApp {
                         .unwrap_or_else(|| t.title.clone());
                     cx.notify();
                     fire_attention_notification(
+                        tool,
                         &title,
-                        Some(&message),
+                        message.as_deref(),
                         &notify_config,
                         agents_source_visible,
                         cx.background_executor().clone(),
@@ -2966,36 +3002,53 @@ impl PaneFlowApp {
                     );
                     // US-016: the turn ended - the question is answered, no
                     // ghost message may survive into the next state.
-                    let mut transcript_to_read: Option<std::path::PathBuf> = None;
+                    let (session_summary, transcript_to_read) = read_stop_summary(params);
                     if let Some(s) = ws.agent_sessions.get_mut(&session_key) {
                         s.message = None;
                         // EP-004 US-015: capture a best-effort summary of the
                         // just-finished turn when the stop hook carried one, so
                         // a conductor reads it via fleet.list / surface.status.
                         // None when the hook provides nothing (the common case).
-                        s.last_result = read_last_result(params);
-                        // EP-004 US-010: the common Claude Code case carries no
-                        // inline summary, only a transcript path - capture it for
-                        // an off-thread backfill once the borrow ends.
-                        if s.last_result.is_none() {
-                            transcript_to_read = read_transcript_path(params);
-                        }
+                        s.last_result = session_summary.clone();
                     }
                     // EP-004 US-020: notify the user the turn ended if they're
                     // looking elsewhere. Read the title before the borrow ends.
                     let ws_title = ws.title.clone();
                     cx.notify();
-                    fire_turn_end_notification(
-                        &ws_title,
-                        &notify_config,
-                        workspace_source_visible,
-                        cx.background_executor().clone(),
-                    );
+                    if let Some(path) = transcript_to_read {
+                        Self::schedule_transcript_turn_end(
+                            Some((workspace_id, session_key)),
+                            path,
+                            Some(TranscriptTurnEndNotification {
+                                agent: tool,
+                                title: ws_title.clone(),
+                                config: notify_config.clone(),
+                                source_visible: workspace_source_visible,
+                                executor: cx.background_executor().clone(),
+                            }),
+                            cx,
+                        );
+                    } else {
+                        fire_turn_end_notification(
+                            tool,
+                            &ws_title,
+                            session_summary.as_deref(),
+                            &notify_config,
+                            workspace_source_visible,
+                            cx.background_executor().clone(),
+                        );
+                    }
                     self.bind_or_resolve_session_surface(
                         workspace_id,
                         session_key,
                         explicit_surface_id,
                         cx,
+                    );
+                    self.record_workspace_rosetta_event(
+                        workspace_id,
+                        session_key,
+                        crate::app::rosetta::RosettaRowState::Finished,
+                        std::time::Instant::now(),
                     );
                     self.sync_attention(cx);
                     // EP-001 US-003 (cli-cockpit): the turn ended - flush any
@@ -3030,36 +3083,57 @@ impl PaneFlowApp {
                     )
                     .detach();
 
-                    // EP-004 US-010: backfill last_result from the Stop-hook
-                    // transcript off the render thread (the inline read above
-                    // stayed None because the hook carried only a path).
-                    if let Some(path) = transcript_to_read {
-                        Self::schedule_transcript_read(workspace_id, session_key, path, cx);
-                    }
-
                     serde_json::json!({"status": "idle"})
-                } else if let Some(t) = self.agents_thread_mut_by_env_id(workspace_id) {
+                } else if let Some(target) = self.agents_thread_target_by_env_id(workspace_id) {
                     // Codex-style: the spinner drops the moment the turn
                     // ends and the relative timestamp returns. No Finished
                     // hold state - `ThreadStatus` has no such variant and
                     // the row's timestamp is the natural rest indicator.
-                    apply_agents_thread_state(t, ai_types::AgentState::Finished, pid);
-                    let title = crate::project::clean_sidebar_title(&t.title)
-                        .unwrap_or_else(|| t.title.clone());
+                    let Some(thread) = self.thread_for_target(target) else {
+                        return serde_json::json!({"error": format!("Unknown workspace_id: {workspace_id}")});
+                    };
+                    let title = crate::project::clean_sidebar_title(&thread.title)
+                        .unwrap_or_else(|| thread.title.clone());
                     // Snapshot what the off-thread ai-title backfill needs
                     // before the &mut borrow on `self` ends.
-                    let thread_id = t.id;
-                    let cwd = t.cwd.clone();
-                    let session_agent = t.terminal_agent.and_then(|a| a.session_agent());
-                    let bound_session = t.session_id.clone();
-                    let title_locked = t.title_user_set;
-                    cx.notify();
-                    fire_turn_end_notification(
-                        &title,
-                        &notify_config,
-                        agents_source_visible,
-                        cx.background_executor().clone(),
+                    let thread_id = thread.id;
+                    let cwd = thread.cwd.clone();
+                    let session_agent = thread.terminal_agent.and_then(|a| a.session_agent());
+                    let bound_session = thread.session_id.clone();
+                    let title_locked = thread.title_user_set;
+                    let (session_summary, transcript_to_read) = read_stop_summary(params);
+                    self.record_agents_thread_rosetta_event(
+                        target,
+                        crate::app::rosetta::RosettaRowState::Finished,
+                        std::time::Instant::now(),
                     );
+                    if let Some(t) = self.agents_thread_mut_by_id(thread_id) {
+                        apply_agents_thread_state(t, ai_types::AgentState::Finished, pid);
+                    }
+                    cx.notify();
+                    if let Some(path) = transcript_to_read {
+                        Self::schedule_transcript_turn_end(
+                            None,
+                            path,
+                            Some(TranscriptTurnEndNotification {
+                                agent: tool,
+                                title: title.clone(),
+                                config: notify_config.clone(),
+                                source_visible: agents_source_visible,
+                                executor: cx.background_executor().clone(),
+                            }),
+                            cx,
+                        );
+                    } else {
+                        fire_turn_end_notification(
+                            tool,
+                            &title,
+                            session_summary.as_deref(),
+                            &notify_config,
+                            agents_source_visible,
+                            cx.background_executor().clone(),
+                        );
+                    }
                     // Parity with `/resume`: at turn end the session's LLM
                     // `ai-title` exists on disk - adopt it as the sidebar
                     // label, unless the user pinned the name via a rename.
@@ -3116,6 +3190,7 @@ impl PaneFlowApp {
                     cx.notify();
                     if errored {
                         fire_agent_exit_notification(
+                            tool,
                             &ws_title,
                             exit_code,
                             &notify_config,
@@ -3132,6 +3207,12 @@ impl PaneFlowApp {
                             explicit_surface_id,
                             cx,
                         );
+                        self.record_workspace_rosetta_event(
+                            workspace_id,
+                            key,
+                            crate::app::rosetta::RosettaRowState::Errored,
+                            std::time::Instant::now(),
+                        );
                     }
                     // Finished (exit 0 / interrupt) intentionally fires no
                     // notification - `ai.stop` already announced the turn
@@ -3140,17 +3221,31 @@ impl PaneFlowApp {
                     self.sync_attention(cx);
                     self.agent_sessions_changed(cx);
                     serde_json::json!({"status": if errored { "errored" } else { "finished" }})
-                } else if let Some(t) = self.agents_thread_mut_by_env_id(workspace_id) {
+                } else if let Some(target) = self.agents_thread_target_by_env_id(workspace_id) {
                     // Agents view mirrors the workspace exit classifier but
                     // keeps the row compact: success returns to timestamp,
                     // crashes become a red indicator (no status text).
                     let state = ai_types::state_for_exit(exit_code);
                     let errored = state == ai_types::AgentState::Errored;
-                    apply_agents_thread_state(t, state, pid);
+                    let Some(thread) = self.thread_for_target(target) else {
+                        return serde_json::json!({"error": format!("Unknown workspace_id: {workspace_id}")});
+                    };
+                    let thread_id = thread.id;
+                    let title = crate::project::clean_sidebar_title(&thread.title)
+                        .unwrap_or_else(|| thread.title.clone());
                     if errored {
-                        let title = crate::project::clean_sidebar_title(&t.title)
-                            .unwrap_or_else(|| t.title.clone());
+                        self.record_agents_thread_rosetta_event(
+                            target,
+                            crate::app::rosetta::RosettaRowState::Errored,
+                            std::time::Instant::now(),
+                        );
+                    }
+                    if let Some(t) = self.agents_thread_mut_by_id(thread_id) {
+                        apply_agents_thread_state(t, state, pid);
+                    }
+                    if errored {
                         fire_agent_exit_notification(
+                            tool,
                             &title,
                             exit_code,
                             &notify_config,
@@ -3202,11 +3297,23 @@ impl PaneFlowApp {
                     // closes (`sweep_stale_pids`).
                     let is_errored =
                         |s: &ai_types::AgentSession| s.state == ai_types::AgentState::Errored;
+                    let mut recent_event = None;
                     let removed = if let Some(p) = pid
-                        && ws.agent_sessions.get(&p).is_some_and(|s| !is_errored(s))
-                        && ws.agent_sessions.remove(&p).is_some()
+                        && let Some(session) = ws.agent_sessions.get(&p)
+                        && !is_errored(session)
                     {
-                        true
+                        if session.state != ai_types::AgentState::Finished {
+                            recent_event = Some(
+                                crate::app::rosetta::rosetta_recent_event_from_workspace_session(
+                                    ws.id,
+                                    &ws.title,
+                                    session,
+                                    crate::app::rosetta::RosettaRowState::Finished,
+                                    std::time::Instant::now(),
+                                ),
+                            );
+                        }
+                        ws.agent_sessions.remove(&p).is_some()
                     } else if pid.is_some_and(|p| ws.agent_sessions.contains_key(&p)) {
                         // Exact-PID match exists but is Errored: keep it, and
                         // do NOT fall through to the tool-name removal (it
@@ -3219,6 +3326,19 @@ impl PaneFlowApp {
                             .find(|(_, s)| Some(s.tool) == tool && !is_errored(s))
                             .map(|(k, _)| *k);
                         if let Some(k) = pid_to_remove {
+                            if let Some(session) = ws.agent_sessions.get(&k)
+                                && session.state != ai_types::AgentState::Finished
+                            {
+                                recent_event = Some(
+                                    crate::app::rosetta::rosetta_recent_event_from_workspace_session(
+                                        ws.id,
+                                        &ws.title,
+                                        session,
+                                        crate::app::rosetta::RosettaRowState::Finished,
+                                        std::time::Instant::now(),
+                                    ),
+                                );
+                            }
                             ws.agent_sessions.remove(&k);
                             true
                         } else {
@@ -3226,6 +3346,9 @@ impl PaneFlowApp {
                         }
                     };
                     if removed {
+                        if let Some(event) = recent_event {
+                            self.rosetta_recent_history.push(event);
+                        }
                         self.sync_attention(cx);
                         // EP-001 US-003 (cli-cockpit): a removed session
                         // leaves a bare shell - always a safe prefill target.
@@ -3233,7 +3356,24 @@ impl PaneFlowApp {
                         cx.notify();
                     }
                     serde_json::json!({"cleared": removed})
-                } else if let Some(t) = self.agents_thread_mut_by_env_id(workspace_id) {
+                } else if let Some(target) = self.agents_thread_target_by_env_id(workspace_id) {
+                    let Some(thread) = self.thread_for_target(target) else {
+                        return serde_json::json!({"error": format!("Unknown workspace_id: {workspace_id}")});
+                    };
+                    let thread_id = thread.id;
+                    let should_record_finished = thread.status
+                        != crate::project::ThreadStatus::Idle
+                        && thread.status != crate::project::ThreadStatus::Failed;
+                    if should_record_finished {
+                        self.record_agents_thread_rosetta_event(
+                            target,
+                            crate::app::rosetta::RosettaRowState::Finished,
+                            std::time::Instant::now(),
+                        );
+                    }
+                    let Some(t) = self.agents_thread_mut_by_id(thread_id) else {
+                        return serde_json::json!({"error": format!("Unknown workspace_id: {workspace_id}")});
+                    };
                     let was_active = clear_agents_thread_on_session_end(t);
                     if was_active {
                         cx.notify();
@@ -3258,6 +3398,26 @@ impl PaneFlowApp {
     fn agents_thread_mut_by_env_id(&mut self, env_id: u64) -> Option<&mut crate::project::Thread> {
         let thread_id = crate::project::thread_id_from_env_id(env_id)?;
         self.agents_thread_mut_by_id(thread_id)
+    }
+
+    fn agents_thread_target_by_env_id(&self, env_id: u64) -> Option<crate::project::AgentsTarget> {
+        let thread_id = crate::project::thread_id_from_env_id(env_id)?;
+        for (project_idx, project) in self.projects.iter().enumerate() {
+            if let Some(thread_idx) = project
+                .threads
+                .iter()
+                .position(|thread| thread.id == thread_id)
+            {
+                return Some(crate::project::AgentsTarget::Thread {
+                    project_idx,
+                    thread_idx,
+                });
+            }
+        }
+        self.chats
+            .iter()
+            .position(|chat| chat.id == thread_id)
+            .map(|chat_idx| crate::project::AgentsTarget::Chat { chat_idx })
     }
 }
 
@@ -3774,11 +3934,11 @@ mod tests {
     fn agent_exit_body_carries_workspace_and_code() {
         assert_eq!(
             crate::agents::notifications::agent_exit_notification_body("api", 1),
-            "api: agent exited with code 1"
+            "api: exited with code 1"
         );
         assert_eq!(
             crate::agents::notifications::agent_exit_notification_body("ws", -1073741510),
-            "ws: agent exited with code -1073741510"
+            "ws: exited with code -1073741510"
         );
     }
 
@@ -3786,7 +3946,7 @@ mod tests {
     fn stalled_body_carries_workspace_and_silence() {
         assert_eq!(
             crate::agents::notifications::stalled_notification_body("api", 300),
-            "api: no agent activity for 300 s"
+            "api: no activity for 300 s"
         );
     }
 
@@ -4481,6 +4641,19 @@ mod tests {
         assert!(super::read_last_result(&serde_json::json!({})).is_none());
     }
 
+    #[test]
+    fn read_notification_message_is_optional_and_sanitized() {
+        let p = serde_json::json!({"hook_payload": {"message": "Approve?"}});
+        assert_eq!(
+            super::read_notification_message(&p).as_deref(),
+            Some("Approve?")
+        );
+
+        let p = serde_json::json!({"message": " \u{202E} "});
+        assert!(super::read_notification_message(&p).is_none());
+        assert!(super::read_notification_message(&serde_json::json!({})).is_none());
+    }
+
     // EP-004 US-010: transcript backfill of last_result.
 
     #[test]
@@ -4516,6 +4689,24 @@ mod tests {
                 .is_none()
         );
         assert!(read_transcript_path(&serde_json::json!({})).is_none());
+    }
+
+    #[test]
+    fn read_stop_summary_uses_inline_before_transcript_path() {
+        #[cfg(windows)]
+        let abs = r"C:\abs\session.jsonl";
+        #[cfg(not(windows))]
+        let abs = "/abs/session.jsonl";
+
+        let p = serde_json::json!({"hook_payload": {"summary": "done", "transcript_path": abs}});
+        let (summary, path) = super::read_stop_summary(&p);
+        assert_eq!(summary.as_deref(), Some("done"));
+        assert!(path.is_none());
+
+        let p = serde_json::json!({"hook_payload": {"transcript_path": abs}});
+        let (summary, path) = super::read_stop_summary(&p);
+        assert!(summary.is_none());
+        assert_eq!(path.as_deref(), Some(std::path::Path::new(abs)));
     }
 
     #[test]

--- a/src-app/src/app/mod.rs
+++ b/src-app/src/app/mod.rs
@@ -27,6 +27,7 @@ pub mod launch_pad;
 pub mod notifications;
 pub mod profile_menu;
 pub mod project_ops;
+pub mod rosetta;
 pub mod self_update_flow;
 pub mod session;
 pub mod sessions_sidebar;

--- a/src-app/src/app/rosetta.rs
+++ b/src-app/src/app/rosetta.rs
@@ -1,0 +1,2619 @@
+//! Pure Rosetta projection helpers.
+//!
+//! This module is intentionally render-agnostic for EP-001: rows are derived
+//! from existing in-memory app state, while follow-up stories can decide how to
+//! paint and activate them.
+#![allow(dead_code)]
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::time::{Duration, Instant};
+
+use gpui::{
+    Animation, AnimationExt, AnyElement, ClickEvent, Context, Focusable as _, InteractiveElement,
+    IntoElement, KeyDownEvent, MouseButton, ParentElement, SharedString, Styled, Transformation,
+    Window, deferred, div, percentage, prelude::*, px, rgb, svg,
+};
+use paneflow_config::schema::AppMode;
+
+use crate::agent_launcher::TerminalAgent;
+use crate::ai_types::{AgentSession, AgentState};
+use crate::app::ipc_handler::find_pane_by_surface_id;
+use crate::project::{AgentsTarget, Project, Thread, ThreadStatus};
+use crate::settings::components::with_alpha;
+use crate::workspace::Workspace;
+
+pub(crate) const ROSETTA_AGENT_TEXT_CAP_CHARS: usize = 512;
+pub(crate) const ROSETTA_TYPED_ACTION_COMPACT_COMMAND_CHARS: usize = 160;
+pub(crate) const ROSETTA_RECENT_EVENT_CAP: usize = 25;
+pub(crate) const ROSETTA_RECENT_EVENT_RETENTION: Duration = Duration::from_secs(5 * 60);
+const ROSETTA_COMPACT_MAX_WIDTH: f32 = 460.;
+const ROSETTA_COMPACT_PASSIVE_MAX_WIDTH: f32 = 360.;
+const ROSETTA_EXPANDED_MAX_WIDTH: f32 = 640.;
+const ROSETTA_CARD_SIDE_GUTTER: f32 = 16.;
+const ROSETTA_CARD_TOP: f32 = 14.;
+const ROSETTA_MAX_PANEL_HEIGHT_RATIO: f32 = 0.70;
+const ROSETTA_MIN_PANEL_HEIGHT: f32 = 260.;
+const ROSETTA_MAX_PANEL_HEIGHT: f32 = 520.;
+const ROSETTA_PANEL_CHROME_HEIGHT: f32 = 92.;
+const ROSETTA_CARD_RADIUS: f32 = 14.;
+pub(crate) const ROSETTA_SNOOZE_DURATION: Duration = Duration::from_secs(10 * 60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RosettaRowState {
+    Errored,
+    WaitingForInput,
+    Stalled,
+    Thinking,
+    Finished,
+}
+
+impl RosettaRowState {
+    pub(crate) fn from_agent_state(state: &AgentState) -> Self {
+        match state {
+            AgentState::Errored => Self::Errored,
+            AgentState::WaitingForInput => Self::WaitingForInput,
+            AgentState::Stalled => Self::Stalled,
+            AgentState::Thinking => Self::Thinking,
+            AgentState::Finished => Self::Finished,
+        }
+    }
+
+    pub(crate) fn from_thread_status(status: ThreadStatus) -> Option<Self> {
+        match status {
+            ThreadStatus::Idle => None,
+            ThreadStatus::Thinking => Some(Self::Thinking),
+            ThreadStatus::WaitingForInput => Some(Self::WaitingForInput),
+            ThreadStatus::Failed => Some(Self::Errored),
+        }
+    }
+
+    fn priority_rank(self) -> u8 {
+        match self {
+            Self::Errored => 5,
+            Self::WaitingForInput => 4,
+            Self::Stalled => 3,
+            Self::Thinking => 2,
+            Self::Finished => 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RosettaFocusTarget {
+    WorkspaceSurface { workspace_id: u64, surface_id: u64 },
+    AgentsThread(AgentsTarget),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RosettaRowSource {
+    WorkspaceSession {
+        workspace_id: u64,
+        pid: u32,
+    },
+    AgentsThread {
+        target: AgentsTarget,
+        thread_id: u64,
+    },
+    RecentEvent {
+        sequence: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RosettaRowKey {
+    WorkspaceSession { workspace_id: u64, pid: u32 },
+    AgentsThread { thread_id: u64 },
+    RecentEvent { sequence: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RosettaRow {
+    pub(crate) source: RosettaRowSource,
+    pub(crate) state: RosettaRowState,
+    pub(crate) tool: Option<TerminalAgent>,
+    pub(crate) workspace_title: Option<String>,
+    pub(crate) thread_title: Option<String>,
+    pub(crate) context: Option<String>,
+    pub(crate) surface_id: Option<u64>,
+    pub(crate) focus_target: Option<RosettaFocusTarget>,
+    pub(crate) message: Option<String>,
+    pub(crate) waiting_secs: Option<u64>,
+    pub(crate) last_activity_secs: Option<u64>,
+    pub(crate) active_tool_name: Option<String>,
+    pub(crate) last_result: Option<String>,
+    pub(crate) typed_action: Option<RosettaTypedAction>,
+    sort_order: usize,
+}
+
+impl RosettaRow {
+    pub(crate) fn key(&self) -> RosettaRowKey {
+        match self.source {
+            RosettaRowSource::WorkspaceSession { workspace_id, pid } => {
+                RosettaRowKey::WorkspaceSession { workspace_id, pid }
+            }
+            RosettaRowSource::AgentsThread { thread_id, .. } => {
+                RosettaRowKey::AgentsThread { thread_id }
+            }
+            RosettaRowSource::RecentEvent { sequence } => RosettaRowKey::RecentEvent { sequence },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RosettaActionRisk {
+    Low,
+    Medium,
+    Destructive,
+    Network,
+    Credential,
+    Publish,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RosettaTypedAction {
+    pub(crate) action_id: Option<String>,
+    pub(crate) command: Option<String>,
+    pub(crate) cwd: Option<String>,
+    pub(crate) tool: Option<TerminalAgent>,
+    pub(crate) risk: RosettaActionRisk,
+}
+
+impl RosettaTypedAction {
+    fn is_complete(&self) -> bool {
+        self.action_id
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+            && self
+                .command
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            && self
+                .cwd
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            && self.tool.is_some()
+    }
+
+    fn direct_approval_allowed_in_compact(&self) -> bool {
+        self.is_complete()
+            && self.command.as_deref().is_some_and(|command| {
+                command.chars().count() <= ROSETTA_TYPED_ACTION_COMPACT_COMMAND_CHARS
+            })
+            && !matches!(
+                self.risk,
+                RosettaActionRisk::Destructive
+                    | RosettaActionRisk::Network
+                    | RosettaActionRisk::Credential
+                    | RosettaActionRisk::Publish
+            )
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct RosettaProjection {
+    pub(crate) rows: Vec<RosettaRow>,
+}
+
+impl RosettaProjection {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RosettaSectionKind {
+    NeedsInput,
+    Failed,
+    Stalled,
+    Running,
+    Recent,
+}
+
+impl RosettaSectionKind {
+    fn title(self) -> &'static str {
+        match self {
+            Self::NeedsInput => "Needs input",
+            Self::Failed => "Failed",
+            Self::Stalled => "Stalled",
+            Self::Running => "Running",
+            Self::Recent => "Recent",
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RosettaSection<'a> {
+    pub(crate) kind: RosettaSectionKind,
+    pub(crate) rows: Vec<&'a RosettaRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RosettaCompactSummary {
+    pub(crate) label: &'static str,
+    pub(crate) title: String,
+    pub(crate) detail: Option<String>,
+    pub(crate) state: RosettaRowState,
+    pub(crate) count: usize,
+    pub(crate) passive_only: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RosettaTargetStatus {
+    Navigable,
+    NoPane,
+    Unavailable,
+}
+
+impl RosettaTargetStatus {
+    fn is_navigable(self) -> bool {
+        matches!(self, Self::Navigable)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RosettaSecondaryAction {
+    Read,
+    Snooze,
+    Dismiss,
+}
+
+pub(crate) fn rosetta_sections(rows: &[RosettaRow]) -> Vec<RosettaSection<'_>> {
+    let mut sections = Vec::new();
+    for kind in [
+        RosettaSectionKind::NeedsInput,
+        RosettaSectionKind::Failed,
+        RosettaSectionKind::Stalled,
+        RosettaSectionKind::Running,
+        RosettaSectionKind::Recent,
+    ] {
+        let section_rows: Vec<_> = rows
+            .iter()
+            .filter(|row| rosetta_section_kind(row.state) == kind)
+            .collect();
+        if !section_rows.is_empty() {
+            sections.push(RosettaSection {
+                kind,
+                rows: section_rows,
+            });
+        }
+    }
+    sections
+}
+
+pub(crate) fn rosetta_compact_summary(rows: &[RosettaRow]) -> Option<RosettaCompactSummary> {
+    let row_refs: Vec<_> = rows.iter().collect();
+    rosetta_compact_summary_for_rows(&row_refs)
+}
+
+fn rosetta_compact_summary_for_rows(rows: &[&RosettaRow]) -> Option<RosettaCompactSummary> {
+    let primary = *rows.first()?;
+    let state = primary.state;
+    let label = rosetta_state_label(state);
+    let count = rows.iter().filter(|row| row.state == state).count();
+    let title = if count > 1 {
+        format!("{count} {}", rosetta_plural_subject(state))
+    } else {
+        rosetta_row_title(primary)
+    };
+    let passive_only = rows
+        .iter()
+        .all(|row| row.state == RosettaRowState::Thinking);
+    let detail = (!passive_only)
+        .then(|| rosetta_row_detail(primary))
+        .flatten();
+
+    Some(RosettaCompactSummary {
+        label,
+        title,
+        detail,
+        state,
+        count,
+        passive_only,
+    })
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RosettaRecentEvent {
+    pub(crate) state: RosettaRowState,
+    pub(crate) tool: Option<TerminalAgent>,
+    pub(crate) workspace_title: Option<String>,
+    pub(crate) thread_title: Option<String>,
+    pub(crate) context: Option<String>,
+    pub(crate) surface_id: Option<u64>,
+    pub(crate) focus_target: Option<RosettaFocusTarget>,
+    pub(crate) message: Option<String>,
+    pub(crate) last_result: Option<String>,
+    pub(crate) occurred_at: Instant,
+    sequence: u64,
+}
+
+impl RosettaRecentEvent {
+    pub(crate) fn new(state: RosettaRowState, occurred_at: Instant) -> Self {
+        Self {
+            state,
+            tool: None,
+            workspace_title: None,
+            thread_title: None,
+            context: None,
+            surface_id: None,
+            focus_target: None,
+            message: None,
+            last_result: None,
+            occurred_at,
+            sequence: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RosettaRecentHistory {
+    events: VecDeque<RosettaRecentEvent>,
+    next_sequence: u64,
+}
+
+impl RosettaRecentHistory {
+    pub(crate) fn push(&mut self, mut event: RosettaRecentEvent) {
+        event.sequence = self.next_sequence;
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        event.message = cap_optional_agent_text(event.message.as_deref());
+        event.last_result = cap_optional_agent_text(event.last_result.as_deref());
+        self.events.push_back(event);
+
+        while self.events.len() > ROSETTA_RECENT_EVENT_CAP {
+            let _ = self.events.pop_front();
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    pub(crate) fn dismiss_sequence(&mut self, sequence: u64) -> bool {
+        let before = self.events.len();
+        self.events.retain(|event| event.sequence != sequence);
+        before != self.events.len()
+    }
+
+    fn visible_events(&self, now: Instant) -> impl Iterator<Item = &RosettaRecentEvent> {
+        self.events
+            .iter()
+            .filter(move |event| elapsed(now, event.occurred_at) <= ROSETTA_RECENT_EVENT_RETENTION)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct WorkspaceSessionRef<'a> {
+    workspace_id: u64,
+    workspace_title: &'a str,
+    pid: u32,
+    session: &'a AgentSession,
+}
+
+impl crate::PaneFlowApp {
+    pub(crate) fn rosetta_projection(&self, now: Instant) -> RosettaProjection {
+        build_rosetta_projection(
+            &self.workspaces,
+            &self.projects,
+            &self.chats,
+            &self.rosetta_recent_history,
+            now,
+        )
+    }
+
+    pub(crate) fn record_workspace_rosetta_event(
+        &mut self,
+        workspace_id: u64,
+        session_key: u32,
+        state: RosettaRowState,
+        occurred_at: Instant,
+    ) {
+        let event = self
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == workspace_id)
+            .and_then(|workspace| {
+                let session = workspace.agent_sessions.get(&session_key)?;
+                Some(rosetta_recent_event_from_workspace_session(
+                    workspace.id,
+                    &workspace.title,
+                    session,
+                    state,
+                    occurred_at,
+                ))
+            });
+        if let Some(event) = event {
+            self.rosetta_recent_history.push(event);
+        }
+    }
+
+    pub(crate) fn record_agents_thread_rosetta_event(
+        &mut self,
+        target: AgentsTarget,
+        state: RosettaRowState,
+        occurred_at: Instant,
+    ) {
+        let event = self.thread_for_target(target).map(|thread| {
+            let context = match target {
+                AgentsTarget::Thread { project_idx, .. } => self
+                    .projects
+                    .get(project_idx)
+                    .map(|project| project.title.as_str()),
+                AgentsTarget::Chat { .. } => Some("Chat"),
+            };
+            rosetta_recent_event_from_agents_thread(thread, target, context, state, occurred_at)
+        });
+        if let Some(event) = event {
+            self.rosetta_recent_history.push(event);
+        }
+    }
+
+    pub(crate) fn render_rosetta_surface(
+        &mut self,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        if !self.cached_config.rosetta_enabled() || !self.rosetta_mode_enabled() {
+            self.reset_rosetta_surface_state();
+            return None;
+        }
+
+        let now = Instant::now();
+        let projection = self.rosetta_projection(now);
+        self.prune_rosetta_action_state(&projection.rows, now);
+        if projection.is_empty() && !self.rosetta_surface_expanded {
+            self.reset_rosetta_surface_state();
+            return None;
+        }
+        if !self.rosetta_passive_display_enabled
+            && !self.rosetta_surface_expanded
+            && projection
+                .rows
+                .iter()
+                .all(|row| row.state == RosettaRowState::Thinking)
+        {
+            self.reset_rosetta_surface_state();
+            return None;
+        }
+
+        let ui = crate::theme::ui_colors();
+        let content = if self.rosetta_surface_expanded {
+            let max_width = rosetta_preferred_card_max_width(window, ROSETTA_EXPANDED_MAX_WIDTH);
+            let max_panel_height = rosetta_panel_max_height(window);
+            self.render_rosetta_expanded(&projection, max_width, max_panel_height, ui, cx)
+        } else {
+            let compact_rows = self.rosetta_compact_rows(&projection.rows);
+            let summary = rosetta_compact_summary_for_rows(&compact_rows)?;
+            let max_width = rosetta_card_max_width(window, self.rosetta_surface_expanded, &summary);
+            self.render_rosetta_compact(&summary, max_width, ui, cx)
+        };
+
+        Some(
+            deferred(
+                div()
+                    .id("rosetta-surface-anchor")
+                    .absolute()
+                    .top(px(ROSETTA_CARD_TOP))
+                    .left_0()
+                    .right_0()
+                    .px(px(ROSETTA_CARD_SIDE_GUTTER))
+                    .flex()
+                    .items_start()
+                    .justify_center()
+                    .child(content),
+            )
+            .with_priority(5)
+            .into_any_element(),
+        )
+    }
+
+    pub(crate) fn handle_toggle_rosetta_surface(
+        &mut self,
+        _: &crate::ToggleRosettaSurface,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.title_bar_files_menu_open = None;
+        self.title_bar_help_menu_open = None;
+        self.workspace_menu_open = None;
+        self.tab_menu_open = None;
+        self.profile_menu_open = None;
+        self.files_menu_open = None;
+        self.agents_view.agents_menu_open = None;
+        self.agents_view.sidebar_actions_menu_open = false;
+        self.agents_view.sidebar_mode_picker_open = false;
+
+        if self.rosetta_surface_expanded {
+            self.close_rosetta_surface(window, cx);
+        } else {
+            self.open_rosetta_surface(window, cx);
+        }
+    }
+
+    fn render_rosetta_compact(
+        &self,
+        summary: &RosettaCompactSummary,
+        max_width: f32,
+        ui: crate::theme::UiColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let status =
+            rosetta_status_indicator(summary.state, ui, SharedString::from("rosetta-compact"));
+        let mut card = div()
+            .id("rosetta-compact")
+            .occlude()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(8.))
+            .w_full()
+            .max_w(px(max_width))
+            .min_h(px(34.))
+            .px(px(11.))
+            .py(px(7.))
+            .rounded(px(ROSETTA_CARD_RADIUS))
+            .bg(ui.surface)
+            .shadow_md()
+            .text_size(px(12.))
+            .text_color(ui.text)
+            .cursor_pointer()
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .on_mouse_down(MouseButton::Right, |_, _, cx| cx.stop_propagation())
+            .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
+                this.open_rosetta_surface(window, cx);
+                cx.stop_propagation();
+            }))
+            .child(status)
+            .child(rosetta_label_chip(summary.label, ui))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .overflow_x_hidden()
+                    .whitespace_nowrap()
+                    .text_ellipsis()
+                    .child(summary.title.clone()),
+            );
+
+        if let Some(detail) = &summary.detail {
+            card = card.child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .overflow_x_hidden()
+                    .whitespace_nowrap()
+                    .text_ellipsis()
+                    .text_color(ui.muted)
+                    .child(detail.clone()),
+            );
+        }
+
+        card.into_any_element()
+    }
+
+    fn render_rosetta_expanded(
+        &mut self,
+        projection: &RosettaProjection,
+        max_width: f32,
+        max_panel_height: f32,
+        ui: crate::theme::UiColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let sections = rosetta_sections(&projection.rows);
+        let flat_rows = rosetta_flat_rows(&sections);
+        let selected = self
+            .rosetta_surface_selected
+            .min(flat_rows.len().saturating_sub(1));
+        self.rosetta_surface_selected = selected;
+        self.rosetta_surface_selected_key = flat_rows.get(selected).map(|row| row.key());
+        let list_max_height = (max_panel_height - ROSETTA_PANEL_CHROME_HEIGHT)
+            .max(ROSETTA_MIN_PANEL_HEIGHT - ROSETTA_PANEL_CHROME_HEIGHT);
+
+        let mut list = div()
+            .id("rosetta-list")
+            .flex()
+            .flex_col()
+            .max_h(px(list_max_height))
+            .overflow_y_scroll()
+            .track_scroll(&self.rosetta_surface_scroll);
+
+        let mut flat_idx = 0;
+        for section in &sections {
+            list = list.child(
+                div()
+                    .px(px(12.))
+                    .pt(px(10.))
+                    .pb(px(4.))
+                    .text_size(px(10.))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_color(ui.muted)
+                    .child(section.kind.title()),
+            );
+            for row in &section.rows {
+                let row = *row;
+                let idx = flat_idx;
+                let status = self.rosetta_target_status(row, cx);
+                list =
+                    list.child(self.render_rosetta_row(row, idx, idx == selected, status, ui, cx));
+                flat_idx += 1;
+            }
+        }
+        if flat_rows.is_empty() {
+            list = list.child(render_rosetta_empty_state(ui));
+        }
+
+        div()
+            .id("rosetta-expanded")
+            .occlude()
+            .track_focus(&self.rosetta_surface_focus)
+            .on_key_down(cx.listener(Self::handle_rosetta_surface_key_down))
+            .on_mouse_down_out(cx.listener(|this, _, window, cx| {
+                this.close_rosetta_surface(window, cx);
+            }))
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .on_mouse_down(MouseButton::Right, |_, _, cx| cx.stop_propagation())
+            .w_full()
+            .max_w(px(max_width))
+            .max_h(px(max_panel_height))
+            .flex()
+            .flex_col()
+            .rounded(px(ROSETTA_CARD_RADIUS))
+            .bg(ui.surface)
+            .shadow_lg()
+            .overflow_hidden()
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap(px(8.))
+                    .px(px(12.))
+                    .py(px(9.))
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .overflow_x_hidden()
+                            .whitespace_nowrap()
+                            .text_ellipsis()
+                            .text_size(px(12.))
+                            .text_color(ui.text)
+                            .child("Rosetta"),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .px(px(7.))
+                            .py(px(3.))
+                            .rounded(px(6.))
+                            .bg(ui.subtle)
+                            .text_size(px(10.))
+                            .text_color(ui.text)
+                            .child("Esc"),
+                    ),
+            )
+            .child(list)
+            .child(self.render_rosetta_footer(&projection.rows, ui, cx))
+            .into_any_element()
+    }
+
+    fn render_rosetta_footer(
+        &self,
+        rows: &[RosettaRow],
+        ui: crate::theme::UiColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let passive_only = !rows.is_empty()
+            && rows
+                .iter()
+                .all(|row| row.state == RosettaRowState::Thinking);
+        let mut footer = div()
+            .px(px(12.))
+            .py(px(7.))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(10.))
+            .text_size(px(10.))
+            .text_color(ui.muted)
+            .child(div().flex_1().min_w_0().child(if rows.is_empty() {
+                "No active Rosetta items"
+            } else {
+                "Enter opens the selected target"
+            }));
+
+        if passive_only {
+            footer = footer.child(
+                rosetta_text_button("Hide running", ui)
+                    .on_click(cx.listener(|this, _: &ClickEvent, _window, cx| {
+                        this.rosetta_passive_display_enabled = false;
+                        this.rosetta_surface_expanded = false;
+                        this.rosetta_surface_selected = 0;
+                        this.rosetta_surface_selected_key = None;
+                        this.persist_setting(
+                            false,
+                            "rosetta_show_passive",
+                            serde_json::Value::Bool(false),
+                            cx,
+                        );
+                        cx.notify();
+                        cx.stop_propagation();
+                    }))
+                    .into_any_element(),
+            );
+        }
+
+        footer.into_any_element()
+    }
+
+    fn render_rosetta_row(
+        &self,
+        row: &RosettaRow,
+        idx: usize,
+        _selected: bool,
+        status: RosettaTargetStatus,
+        ui: crate::theme::UiColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let row_id = SharedString::from(format!("rosetta-row-{idx}"));
+        let row_key = row.key();
+        let detail = rosetta_row_detail(row);
+        let is_navigable = status.is_navigable();
+        let is_read = self.rosetta_read_rows.contains(&row_key);
+        let mut title_el = div()
+            .min_w_0()
+            .overflow_x_hidden()
+            .whitespace_nowrap()
+            .text_ellipsis()
+            .text_color(if is_read { ui.muted } else { ui.text })
+            .child(rosetta_row_title(row));
+        if detail.is_some() {
+            title_el = title_el.flex_none().max_w(px(180.));
+        } else {
+            title_el = title_el.flex_1();
+        }
+
+        let mut actions = div()
+            .flex_none()
+            .ml_auto()
+            .flex()
+            .flex_row()
+            .justify_end()
+            .items_center()
+            .gap(px(4.));
+        if let Some(time) = rosetta_row_time(row) {
+            actions = actions.child(
+                div()
+                    .flex_none()
+                    .w(px(36.))
+                    .text_align(gpui::TextAlign::Right)
+                    .text_size(px(10.))
+                    .text_color(ui.muted)
+                    .child(time),
+            );
+        }
+        let secondary_actions = rosetta_secondary_actions(row, is_read);
+        let has_dismiss = secondary_actions.contains(&RosettaSecondaryAction::Dismiss);
+        for action in secondary_actions
+            .into_iter()
+            .filter(|action| *action != RosettaSecondaryAction::Dismiss)
+        {
+            actions = actions.child(self.render_rosetta_secondary_action(row_key, action, ui, cx));
+        }
+        actions = actions.child(self.render_rosetta_primary_action(
+            row_key,
+            idx,
+            rosetta_primary_action_label(row, status),
+            status,
+            ui,
+            cx,
+        ));
+        if has_dismiss {
+            actions = actions.child(self.render_rosetta_dismiss_action(row_key, ui, cx));
+        }
+
+        let mut row_el = div()
+            .id(row_id)
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(8.))
+            .px(px(12.))
+            .py(px(7.))
+            .text_size(px(12.))
+            .when(is_read, |d| d.opacity(0.68))
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .on_mouse_down(MouseButton::Right, |_, _, cx| cx.stop_propagation())
+            .child(rosetta_status_indicator(
+                row.state,
+                ui,
+                SharedString::from(format!("rosetta-row-{idx}")),
+            ))
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .flex_1()
+                    .min_w_0()
+                    .gap(px(6.))
+                    .child(
+                        div()
+                            .flex_none()
+                            .text_color(if is_read { ui.muted } else { ui.text })
+                            .font_weight(gpui::FontWeight::MEDIUM)
+                            .child(rosetta_agent_label(row)),
+                    )
+                    .when(row.state == RosettaRowState::WaitingForInput, |d| {
+                        d.child(rosetta_attention_badge(ui))
+                    })
+                    .child(title_el)
+                    .when_some(detail, |d, detail| {
+                        d.child(
+                            div()
+                                .flex_1()
+                                .min_w_0()
+                                .overflow_x_hidden()
+                                .whitespace_nowrap()
+                                .text_ellipsis()
+                                .text_size(px(11.))
+                                .text_color(if is_navigable {
+                                    ui.muted
+                                } else {
+                                    with_alpha(ui.muted, 0.78)
+                                })
+                                .child(detail),
+                        )
+                    })
+                    .when_some(rosetta_row_context(row), |d, context| {
+                        d.child(
+                            div()
+                                .flex_none()
+                                .max_w(px(118.))
+                                .overflow_x_hidden()
+                                .whitespace_nowrap()
+                                .text_ellipsis()
+                                .text_size(px(10.))
+                                .text_color(ui.muted)
+                                .child(context),
+                        )
+                    }),
+            )
+            .child(actions);
+
+        if is_navigable {
+            row_el = row_el.cursor_pointer().on_click(cx.listener(
+                move |this, _: &ClickEvent, window, cx| {
+                    this.rosetta_surface_selected = idx;
+                    this.rosetta_surface_selected_key = Some(row_key);
+                    let _ = this.activate_rosetta_row_by_key(row_key, window, cx);
+                    cx.stop_propagation();
+                },
+            ));
+        } else {
+            row_el = row_el.on_click(cx.listener(move |this, _: &ClickEvent, _window, cx| {
+                this.rosetta_surface_selected = idx;
+                this.rosetta_surface_selected_key = Some(row_key);
+                this.explain_unavailable_rosetta_row(status, cx);
+                cx.notify();
+                cx.stop_propagation();
+            }));
+        }
+
+        row_el.into_any_element()
+    }
+
+    fn render_rosetta_primary_action(
+        &self,
+        row_key: RosettaRowKey,
+        idx: usize,
+        label: &'static str,
+        status: RosettaTargetStatus,
+        ui: crate::theme::UiColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let is_navigable = status.is_navigable();
+        let button = rosetta_text_button(label, ui).text_color(if is_navigable {
+            ui.text
+        } else {
+            ui.muted
+        });
+
+        if is_navigable {
+            button
+                .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+                    this.rosetta_surface_selected = idx;
+                    this.rosetta_surface_selected_key = Some(row_key);
+                    let _ = this.activate_rosetta_row_by_key(row_key, window, cx);
+                    cx.stop_propagation();
+                }))
+                .into_any_element()
+        } else {
+            button
+                .opacity(0.62)
+                .on_click(cx.listener(move |this, _: &ClickEvent, _window, cx| {
+                    this.rosetta_surface_selected = idx;
+                    this.rosetta_surface_selected_key = Some(row_key);
+                    this.explain_unavailable_rosetta_row(status, cx);
+                    cx.stop_propagation();
+                }))
+                .into_any_element()
+        }
+    }
+
+    fn render_rosetta_secondary_action(
+        &self,
+        row_key: RosettaRowKey,
+        action: RosettaSecondaryAction,
+        ui: crate::theme::UiColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let label = match action {
+            RosettaSecondaryAction::Read => "Read",
+            RosettaSecondaryAction::Snooze => "Snooze",
+            RosettaSecondaryAction::Dismiss => "Dismiss",
+        };
+
+        rosetta_text_button(label, ui)
+            .on_click(cx.listener(move |this, _: &ClickEvent, _window, cx| {
+                match action {
+                    RosettaSecondaryAction::Read => this.mark_rosetta_row_read(row_key, cx),
+                    RosettaSecondaryAction::Snooze => this.snooze_rosetta_row(row_key, cx),
+                    RosettaSecondaryAction::Dismiss => this.dismiss_rosetta_row(row_key, cx),
+                }
+                cx.stop_propagation();
+            }))
+            .into_any_element()
+    }
+
+    fn render_rosetta_dismiss_action(
+        &self,
+        row_key: RosettaRowKey,
+        ui: crate::theme::UiColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        div()
+            .id(SharedString::from(format!(
+                "rosetta-action-dismiss-{row_key:?}"
+            )))
+            .occlude()
+            .flex_none()
+            .w(px(20.))
+            .h(px(20.))
+            .flex()
+            .items_center()
+            .justify_center()
+            .rounded(px(6.))
+            .text_color(ui.muted)
+            .bg(with_alpha(ui.text, 0.06))
+            .cursor_pointer()
+            .hover(|s| s.bg(with_alpha(ui.text, 0.10)).text_color(ui.text))
+            .tooltip(crate::ui_primitives::text_tooltip("Dismiss"))
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .on_mouse_down(MouseButton::Right, |_, _, cx| cx.stop_propagation())
+            .on_click(cx.listener(move |this, _: &ClickEvent, _window, cx| {
+                this.dismiss_rosetta_row(row_key, cx);
+                cx.stop_propagation();
+            }))
+            .child(
+                svg()
+                    .size(px(12.))
+                    .flex_none()
+                    .path("icons/trash.svg")
+                    .text_color(ui.muted),
+            )
+            .into_any_element()
+    }
+
+    fn open_rosetta_surface(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let projection = self.rosetta_projection(Instant::now());
+        self.rosetta_surface_expanded = true;
+        self.rosetta_surface_selected = self
+            .rosetta_surface_selected
+            .min(projection.rows.len().saturating_sub(1));
+        self.rosetta_surface_selected_key = projection
+            .rows
+            .get(self.rosetta_surface_selected)
+            .map(RosettaRow::key);
+        self.rosetta_surface_focus.focus(window, cx);
+        self.rosetta_surface_pending_focus = false;
+        cx.notify();
+    }
+
+    fn close_rosetta_surface(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.rosetta_surface_expanded = false;
+        self.rosetta_surface_selected = 0;
+        self.rosetta_surface_selected_key = None;
+        self.rosetta_surface_pending_focus = false;
+        self.restore_rosetta_focus(window, cx);
+        cx.notify();
+    }
+
+    fn handle_rosetta_surface_key_down(
+        &mut self,
+        event: &KeyDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let projection = self.rosetta_projection(Instant::now());
+        let sections = rosetta_sections(&projection.rows);
+        let flat_rows = rosetta_flat_rows(&sections);
+        let row_count = flat_rows.len();
+        match event.keystroke.key.as_str() {
+            "escape" => {
+                self.close_rosetta_surface(window, cx);
+                cx.stop_propagation();
+            }
+            "up" if row_count > 0 => {
+                self.rosetta_surface_selected = self.rosetta_surface_selected.saturating_sub(1);
+                self.rosetta_surface_selected_key = flat_rows
+                    .get(self.rosetta_surface_selected)
+                    .map(|row| row.key());
+                cx.notify();
+                cx.stop_propagation();
+            }
+            "down" if row_count > 0 => {
+                self.rosetta_surface_selected =
+                    (self.rosetta_surface_selected + 1).min(row_count - 1);
+                self.rosetta_surface_selected_key = flat_rows
+                    .get(self.rosetta_surface_selected)
+                    .map(|row| row.key());
+                cx.notify();
+                cx.stop_propagation();
+            }
+            "enter" if row_count > 0 => {
+                if let Some(key) = self.rosetta_surface_selected_key {
+                    let _ = self.activate_rosetta_row_by_key(key, window, cx);
+                } else {
+                    let selected = self.rosetta_surface_selected.min(row_count - 1);
+                    if let Some(row) = flat_rows.get(selected) {
+                        let _ = self.activate_rosetta_row_by_key(row.key(), window, cx);
+                    }
+                }
+                cx.stop_propagation();
+            }
+            _ => {}
+        }
+    }
+
+    fn activate_rosetta_row_by_key(
+        &mut self,
+        key: RosettaRowKey,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let now = Instant::now();
+        let projection = self.rosetta_projection(now);
+        self.prune_rosetta_action_state(&projection.rows, now);
+        let Some(row) = projection.rows.iter().find(|row| row.key() == key) else {
+            self.explain_unavailable_rosetta_row(RosettaTargetStatus::Unavailable, cx);
+            return false;
+        };
+        let status = self.rosetta_target_status(row, cx);
+        let Some(target) = row.focus_target else {
+            self.explain_unavailable_rosetta_row(status, cx);
+            return false;
+        };
+        if !status.is_navigable() || !self.activate_rosetta_target(target, window, cx) {
+            self.explain_unavailable_rosetta_row(status, cx);
+            return false;
+        }
+        true
+    }
+
+    fn activate_rosetta_target(
+        &mut self,
+        target: RosettaFocusTarget,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        match target {
+            RosettaFocusTarget::WorkspaceSurface { surface_id, .. } => {
+                let Some((ws_idx, pane, tab_idx)) =
+                    find_pane_by_surface_id(&self.workspaces, surface_id, cx)
+                else {
+                    cx.notify();
+                    return false;
+                };
+                self.mode = AppMode::Cli;
+                self.active_idx = ws_idx;
+                pane.update(cx, |pane, cx| {
+                    if pane.selected_idx != tab_idx {
+                        pane.selected_idx = tab_idx;
+                    }
+                    cx.notify();
+                });
+                pane.read(cx).focus_handle(cx).focus(window, cx);
+                self.jump_cursor = Some(surface_id);
+                self.rosetta_surface_expanded = false;
+                self.rosetta_surface_selected = 0;
+                self.rosetta_surface_selected_key = None;
+                cx.notify();
+                true
+            }
+            RosettaFocusTarget::AgentsThread(target) => {
+                let Some(thread_id) = self.thread_for_target(target).map(|thread| thread.id) else {
+                    cx.notify();
+                    return false;
+                };
+                self.mode = AppMode::Agents;
+                self.select_agents_target(target, cx);
+                if let Some(view) = self
+                    .agents_view
+                    .agents_terminal_view_cache
+                    .get(&thread_id)
+                    .cloned()
+                {
+                    view.read(cx).focus_handle(cx).focus(window, cx);
+                }
+                self.rosetta_surface_expanded = false;
+                self.rosetta_surface_selected = 0;
+                self.rosetta_surface_selected_key = None;
+                cx.notify();
+                true
+            }
+        }
+    }
+
+    fn snooze_rosetta_row(&mut self, key: RosettaRowKey, cx: &mut Context<Self>) {
+        let until = Instant::now()
+            .checked_add(ROSETTA_SNOOZE_DURATION)
+            .unwrap_or_else(Instant::now);
+        self.rosetta_snoozed_rows.insert(key, until);
+        self.show_toast("Rosetta snoozed this waiting row for 10 minutes", cx);
+        cx.notify();
+    }
+
+    fn mark_rosetta_row_read(&mut self, key: RosettaRowKey, cx: &mut Context<Self>) {
+        if matches!(key, RosettaRowKey::RecentEvent { .. }) {
+            self.rosetta_read_rows.insert(key);
+        }
+        cx.notify();
+    }
+
+    fn dismiss_rosetta_row(&mut self, key: RosettaRowKey, cx: &mut Context<Self>) {
+        match key {
+            RosettaRowKey::RecentEvent { sequence } => {
+                if self.rosetta_recent_history.dismiss_sequence(sequence) {
+                    self.rosetta_surface_selected = self.rosetta_surface_selected.saturating_sub(1);
+                    self.rosetta_surface_selected_key = None;
+                }
+            }
+            _ => {
+                self.rosetta_dismissed_rows.insert(key);
+            }
+        }
+        cx.notify();
+    }
+
+    fn explain_unavailable_rosetta_row(
+        &mut self,
+        status: RosettaTargetStatus,
+        cx: &mut Context<Self>,
+    ) {
+        let message = match status {
+            RosettaTargetStatus::Navigable => "Rosetta target refreshed",
+            RosettaTargetStatus::NoPane => "Rosetta has no pane for this row",
+            RosettaTargetStatus::Unavailable => "Rosetta target unavailable",
+        };
+        self.show_toast(message, cx);
+    }
+
+    fn restore_rosetta_focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match self.mode {
+            AppMode::Cli | AppMode::Diff => {
+                if let Some(ws) = self.workspaces.get_mut(self.active_idx) {
+                    ws.focus_first(window, cx);
+                }
+            }
+            AppMode::Agents => {
+                let Some(target) = self.current_thread_view_target() else {
+                    return;
+                };
+                let Some(thread_id) = self.thread_for_target(target).map(|thread| thread.id) else {
+                    return;
+                };
+                if let Some(view) = self
+                    .agents_view
+                    .agents_terminal_view_cache
+                    .get(&thread_id)
+                    .cloned()
+                {
+                    view.read(cx).focus_handle(cx).focus(window, cx);
+                }
+            }
+        }
+    }
+
+    fn rosetta_target_status(&self, row: &RosettaRow, cx: &Context<Self>) -> RosettaTargetStatus {
+        match row.focus_target {
+            None => RosettaTargetStatus::NoPane,
+            Some(RosettaFocusTarget::WorkspaceSurface { surface_id, .. }) => {
+                if find_pane_by_surface_id(&self.workspaces, surface_id, cx).is_some() {
+                    RosettaTargetStatus::Navigable
+                } else {
+                    RosettaTargetStatus::Unavailable
+                }
+            }
+            Some(RosettaFocusTarget::AgentsThread(target)) => {
+                if self.thread_for_target(target).is_some() {
+                    RosettaTargetStatus::Navigable
+                } else {
+                    RosettaTargetStatus::Unavailable
+                }
+            }
+        }
+    }
+
+    fn prune_rosetta_action_state(&mut self, rows: &[RosettaRow], now: Instant) {
+        let live_states: HashMap<_, _> = rows.iter().map(|row| (row.key(), row.state)).collect();
+        self.rosetta_snoozed_rows.retain(|key, until| {
+            *until > now && live_states.get(key) == Some(&RosettaRowState::WaitingForInput)
+        });
+        self.rosetta_dismissed_rows
+            .retain(|key| live_states.get(key) == Some(&RosettaRowState::Errored));
+        self.rosetta_read_rows
+            .retain(|key| live_states.contains_key(key));
+    }
+
+    fn rosetta_compact_rows<'a>(&self, rows: &'a [RosettaRow]) -> Vec<&'a RosettaRow> {
+        let snoozed: HashSet<_> = self.rosetta_snoozed_rows.keys().copied().collect();
+        rosetta_compact_rows(
+            rows,
+            &snoozed,
+            &self.rosetta_dismissed_rows,
+            &self.rosetta_read_rows,
+        )
+    }
+
+    pub(crate) fn sync_rosetta_config_state(&mut self) {
+        self.rosetta_passive_display_enabled = self.cached_config.rosetta_show_passive_enabled();
+        if !self.cached_config.rosetta_enabled() || !self.rosetta_mode_enabled() {
+            self.reset_rosetta_surface_state();
+        }
+    }
+
+    fn rosetta_mode_enabled(&self) -> bool {
+        matches!(self.mode, AppMode::Cli | AppMode::Agents)
+    }
+
+    fn reset_rosetta_surface_state(&mut self) {
+        self.rosetta_surface_expanded = false;
+        self.rosetta_surface_selected = 0;
+        self.rosetta_surface_selected_key = None;
+        self.rosetta_surface_pending_focus = false;
+    }
+}
+
+pub(crate) fn build_rosetta_projection(
+    workspaces: &[Workspace],
+    projects: &[Project],
+    chats: &[Thread],
+    recent_history: &RosettaRecentHistory,
+    now: Instant,
+) -> RosettaProjection {
+    let workspace_sessions = workspace_session_refs(workspaces);
+    build_rosetta_projection_from_parts(&workspace_sessions, projects, chats, recent_history, now)
+}
+
+fn build_rosetta_projection_from_parts(
+    workspace_sessions: &[WorkspaceSessionRef<'_>],
+    projects: &[Project],
+    chats: &[Thread],
+    recent_history: &RosettaRecentHistory,
+    now: Instant,
+) -> RosettaProjection {
+    let mut rows = Vec::new();
+    let mut sort_order = 0;
+
+    for source in workspace_sessions {
+        rows.push(row_from_workspace_session(*source, now, sort_order));
+        sort_order += 1;
+    }
+
+    for (project_idx, project) in projects.iter().enumerate() {
+        for (thread_idx, thread) in project.threads.iter().enumerate() {
+            let Some(state) = RosettaRowState::from_thread_status(thread.status) else {
+                continue;
+            };
+            let target = AgentsTarget::Thread {
+                project_idx,
+                thread_idx,
+            };
+            rows.push(row_from_agents_thread(
+                thread,
+                state,
+                target,
+                Some(project.title.as_str()),
+                sort_order,
+            ));
+            sort_order += 1;
+        }
+    }
+
+    for (chat_idx, chat) in chats.iter().enumerate() {
+        let Some(state) = RosettaRowState::from_thread_status(chat.status) else {
+            continue;
+        };
+        rows.push(row_from_agents_thread(
+            chat,
+            state,
+            AgentsTarget::Chat { chat_idx },
+            Some("Chat"),
+            sort_order,
+        ));
+        sort_order += 1;
+    }
+
+    for event in recent_history.visible_events(now) {
+        rows.push(row_from_recent_event(event, now, sort_order));
+        sort_order += 1;
+    }
+
+    rank_rows(&mut rows);
+    RosettaProjection { rows }
+}
+
+fn workspace_session_refs(workspaces: &[Workspace]) -> Vec<WorkspaceSessionRef<'_>> {
+    let mut refs = Vec::new();
+
+    for workspace in workspaces {
+        let mut sessions: Vec<_> = workspace.agent_sessions.iter().collect();
+        sessions.sort_by(|(pid_a, session_a), (pid_b, session_b)| {
+            session_a
+                .tool
+                .display_rank()
+                .cmp(&session_b.tool.display_rank())
+                .then_with(|| pid_a.cmp(pid_b))
+        });
+
+        for (pid, session) in sessions {
+            refs.push(WorkspaceSessionRef {
+                workspace_id: workspace.id,
+                workspace_title: &workspace.title,
+                pid: *pid,
+                session,
+            });
+        }
+    }
+
+    refs
+}
+
+fn row_from_workspace_session(
+    source: WorkspaceSessionRef<'_>,
+    now: Instant,
+    sort_order: usize,
+) -> RosettaRow {
+    let session = source.session;
+    RosettaRow {
+        source: RosettaRowSource::WorkspaceSession {
+            workspace_id: source.workspace_id,
+            pid: source.pid,
+        },
+        state: RosettaRowState::from_agent_state(&session.state),
+        tool: Some(session.tool),
+        workspace_title: Some(source.workspace_title.to_string()),
+        thread_title: None,
+        context: None,
+        surface_id: session.surface_id,
+        focus_target: session
+            .surface_id
+            .map(|surface_id| RosettaFocusTarget::WorkspaceSurface {
+                workspace_id: source.workspace_id,
+                surface_id,
+            }),
+        message: cap_optional_agent_text(session.message.as_deref()),
+        waiting_secs: session
+            .waiting_since
+            .map(|since| elapsed(now, since).as_secs()),
+        last_activity_secs: Some(elapsed(now, session.last_activity).as_secs()),
+        active_tool_name: cap_optional_agent_text(session.active_tool_name.as_deref()),
+        last_result: cap_optional_agent_text(session.last_result.as_deref()),
+        typed_action: None,
+        sort_order,
+    }
+}
+
+fn row_from_agents_thread(
+    thread: &Thread,
+    state: RosettaRowState,
+    target: AgentsTarget,
+    context: Option<&str>,
+    sort_order: usize,
+) -> RosettaRow {
+    RosettaRow {
+        source: RosettaRowSource::AgentsThread {
+            target,
+            thread_id: thread.id,
+        },
+        state,
+        tool: Some(thread_tool(thread)),
+        workspace_title: None,
+        thread_title: Some(thread.title.clone()),
+        context: context.map(ToOwned::to_owned),
+        surface_id: None,
+        focus_target: Some(RosettaFocusTarget::AgentsThread(target)),
+        message: None,
+        waiting_secs: None,
+        last_activity_secs: None,
+        active_tool_name: None,
+        last_result: None,
+        typed_action: None,
+        sort_order,
+    }
+}
+
+fn row_from_recent_event(
+    event: &RosettaRecentEvent,
+    now: Instant,
+    sort_order: usize,
+) -> RosettaRow {
+    RosettaRow {
+        source: RosettaRowSource::RecentEvent {
+            sequence: event.sequence,
+        },
+        state: event.state,
+        tool: event.tool,
+        workspace_title: event.workspace_title.clone(),
+        thread_title: event.thread_title.clone(),
+        context: event.context.clone(),
+        surface_id: event.surface_id,
+        focus_target: event.focus_target,
+        message: event.message.clone(),
+        waiting_secs: None,
+        last_activity_secs: Some(elapsed(now, event.occurred_at).as_secs()),
+        active_tool_name: None,
+        last_result: event.last_result.clone(),
+        typed_action: None,
+        sort_order,
+    }
+}
+
+pub(crate) fn rosetta_recent_event_from_workspace_session(
+    workspace_id: u64,
+    workspace_title: &str,
+    session: &AgentSession,
+    state: RosettaRowState,
+    occurred_at: Instant,
+) -> RosettaRecentEvent {
+    let mut event = RosettaRecentEvent::new(state, occurred_at);
+    event.tool = Some(session.tool);
+    event.workspace_title = Some(workspace_title.to_string());
+    event.surface_id = session.surface_id;
+    event.focus_target =
+        session
+            .surface_id
+            .map(|surface_id| RosettaFocusTarget::WorkspaceSurface {
+                workspace_id,
+                surface_id,
+            });
+    event.message = session.message.clone();
+    event.last_result = session.last_result.clone();
+    event
+}
+
+pub(crate) fn rosetta_recent_event_from_agents_thread(
+    thread: &Thread,
+    target: AgentsTarget,
+    context: Option<&str>,
+    state: RosettaRowState,
+    occurred_at: Instant,
+) -> RosettaRecentEvent {
+    let mut event = RosettaRecentEvent::new(state, occurred_at);
+    event.tool = Some(thread_tool(thread));
+    event.thread_title = Some(thread.title.clone());
+    event.context = context.map(ToOwned::to_owned);
+    event.focus_target = Some(RosettaFocusTarget::AgentsThread(target));
+    event
+}
+
+fn rank_rows(rows: &mut [RosettaRow]) {
+    rows.sort_by(|a, b| {
+        b.state
+            .priority_rank()
+            .cmp(&a.state.priority_rank())
+            .then_with(|| compare_waiting_age(a, b))
+            .then_with(|| a.sort_order.cmp(&b.sort_order))
+    });
+}
+
+fn compare_waiting_age(a: &RosettaRow, b: &RosettaRow) -> std::cmp::Ordering {
+    match (a.state, b.state, a.waiting_secs, b.waiting_secs) {
+        (
+            RosettaRowState::WaitingForInput,
+            RosettaRowState::WaitingForInput,
+            Some(a_secs),
+            Some(b_secs),
+        ) => b_secs.cmp(&a_secs),
+        _ => std::cmp::Ordering::Equal,
+    }
+}
+
+fn thread_tool(thread: &Thread) -> TerminalAgent {
+    match thread.terminal_agent {
+        Some(agent) => agent,
+        None => TerminalAgent::from_agent_kind(thread.agent),
+    }
+}
+
+fn elapsed(now: Instant, then: Instant) -> Duration {
+    now.checked_duration_since(then).unwrap_or(Duration::ZERO)
+}
+
+fn cap_optional_agent_text(text: Option<&str>) -> Option<String> {
+    text.map(cap_agent_text)
+}
+
+fn cap_agent_text(text: &str) -> String {
+    let without_ansi = strip_ansi_sequences(text);
+    let without_bidi = crate::markdown::strip_bidi_zero_width(without_ansi);
+    let mut chars = without_bidi.chars().filter_map(|c| match c {
+        '\n' | '\r' | '\t' => Some(' '),
+        '\u{0000}'..='\u{001f}' | '\u{007f}' | '\u{0080}'..='\u{009f}' => None,
+        _ => Some(c),
+    });
+    let mut capped: String = chars.by_ref().take(ROSETTA_AGENT_TEXT_CAP_CHARS).collect();
+    if chars.next().is_some() {
+        while capped.chars().count() > ROSETTA_AGENT_TEXT_CAP_CHARS.saturating_sub(3) {
+            let _ = capped.pop();
+        }
+        capped.push_str("...");
+    }
+    capped
+}
+
+fn rosetta_preferred_card_max_width(window: &Window, preferred: f32) -> f32 {
+    let viewport_w = f32::from(window.viewport_size().width);
+    let available = (viewport_w - (ROSETTA_CARD_SIDE_GUTTER * 2.)).max(240.);
+    preferred.min(available)
+}
+
+fn strip_ansi_sequences(text: &str) -> String {
+    let mut sanitized = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c != '\x1b' {
+            sanitized.push(c);
+            continue;
+        }
+
+        match chars.peek().copied() {
+            Some('[') => {
+                let _ = chars.next();
+                for seq in chars.by_ref() {
+                    if ('\u{0040}'..='\u{007e}').contains(&seq) {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                let _ = chars.next();
+                let mut saw_esc = false;
+                for seq in chars.by_ref() {
+                    if seq == '\u{0007}' || (saw_esc && seq == '\\') {
+                        break;
+                    }
+                    saw_esc = seq == '\x1b';
+                }
+            }
+            Some(_) => {
+                let _ = chars.next();
+            }
+            None => {}
+        }
+    }
+
+    sanitized
+}
+
+fn rosetta_card_max_width(window: &Window, expanded: bool, summary: &RosettaCompactSummary) -> f32 {
+    let preferred = if expanded {
+        ROSETTA_EXPANDED_MAX_WIDTH
+    } else if summary.passive_only {
+        ROSETTA_COMPACT_PASSIVE_MAX_WIDTH
+    } else {
+        ROSETTA_COMPACT_MAX_WIDTH
+    };
+    rosetta_preferred_card_max_width(window, preferred)
+}
+
+fn rosetta_panel_max_height(window: &Window) -> f32 {
+    let viewport_h = f32::from(window.viewport_size().height);
+    (viewport_h * ROSETTA_MAX_PANEL_HEIGHT_RATIO)
+        .clamp(ROSETTA_MIN_PANEL_HEIGHT, ROSETTA_MAX_PANEL_HEIGHT)
+}
+
+fn rosetta_flat_rows<'a>(sections: &'a [RosettaSection<'a>]) -> Vec<&'a RosettaRow> {
+    sections
+        .iter()
+        .flat_map(|section| section.rows.iter().copied())
+        .collect()
+}
+
+fn rosetta_compact_rows<'a>(
+    rows: &'a [RosettaRow],
+    snoozed: &HashSet<RosettaRowKey>,
+    dismissed: &HashSet<RosettaRowKey>,
+    read: &HashSet<RosettaRowKey>,
+) -> Vec<&'a RosettaRow> {
+    let mut compact_rows: Vec<_> = rows.iter().collect();
+    compact_rows.sort_by(|a, b| {
+        rosetta_compact_priority(b, snoozed, dismissed, read)
+            .cmp(&rosetta_compact_priority(a, snoozed, dismissed, read))
+            .then_with(|| a.sort_order.cmp(&b.sort_order))
+    });
+    compact_rows
+        .into_iter()
+        .filter(|row| !read.contains(&row.key()))
+        .filter(|row| !(dismissed.contains(&row.key()) && row.state == RosettaRowState::Errored))
+        .collect()
+}
+
+fn rosetta_compact_priority(
+    row: &RosettaRow,
+    snoozed: &HashSet<RosettaRowKey>,
+    dismissed: &HashSet<RosettaRowKey>,
+    read: &HashSet<RosettaRowKey>,
+) -> u8 {
+    if read.contains(&row.key()) {
+        return 0;
+    }
+    if dismissed.contains(&row.key()) && row.state == RosettaRowState::Errored {
+        return 0;
+    }
+    if snoozed.contains(&row.key()) && row.state == RosettaRowState::WaitingForInput {
+        return 1;
+    }
+    row.state.priority_rank()
+}
+
+fn rosetta_section_kind(state: RosettaRowState) -> RosettaSectionKind {
+    match state {
+        RosettaRowState::WaitingForInput => RosettaSectionKind::NeedsInput,
+        RosettaRowState::Errored => RosettaSectionKind::Failed,
+        RosettaRowState::Stalled => RosettaSectionKind::Stalled,
+        RosettaRowState::Thinking => RosettaSectionKind::Running,
+        RosettaRowState::Finished => RosettaSectionKind::Recent,
+    }
+}
+
+fn rosetta_state_label(state: RosettaRowState) -> &'static str {
+    match state {
+        RosettaRowState::WaitingForInput => "needs response",
+        RosettaRowState::Errored => "failed",
+        RosettaRowState::Stalled => "stalled",
+        RosettaRowState::Thinking => "running",
+        RosettaRowState::Finished => "done",
+    }
+}
+
+fn rosetta_plural_subject(state: RosettaRowState) -> &'static str {
+    match state {
+        RosettaRowState::WaitingForInput => "need responses",
+        RosettaRowState::Errored => "failed",
+        RosettaRowState::Stalled => "stalled",
+        RosettaRowState::Thinking => "running",
+        RosettaRowState::Finished => "done",
+    }
+}
+
+fn rosetta_primary_action_label(row: &RosettaRow, status: RosettaTargetStatus) -> &'static str {
+    match status {
+        RosettaTargetStatus::NoPane => "No pane",
+        RosettaTargetStatus::Unavailable => "Unavailable",
+        RosettaTargetStatus::Navigable => {
+            if row.state == RosettaRowState::WaitingForInput {
+                "Reply"
+            } else if rosetta_direct_approval_controls(row, false).is_some() {
+                "Review"
+            } else {
+                "Open"
+            }
+        }
+    }
+}
+
+fn rosetta_secondary_actions(row: &RosettaRow, is_read: bool) -> Vec<RosettaSecondaryAction> {
+    let mut actions = Vec::new();
+    if matches!(row.source, RosettaRowSource::RecentEvent { .. }) && !is_read {
+        actions.push(RosettaSecondaryAction::Read);
+    }
+    match row.state {
+        RosettaRowState::WaitingForInput => actions.push(RosettaSecondaryAction::Snooze),
+        RosettaRowState::Errored => actions.push(RosettaSecondaryAction::Dismiss),
+        RosettaRowState::Finished if matches!(row.source, RosettaRowSource::RecentEvent { .. }) => {
+            actions.push(RosettaSecondaryAction::Dismiss);
+        }
+        RosettaRowState::Stalled | RosettaRowState::Thinking | RosettaRowState::Finished => {}
+    }
+    actions
+}
+
+fn rosetta_direct_approval_controls(
+    row: &RosettaRow,
+    expanded: bool,
+) -> Option<(&'static str, &'static str)> {
+    let action = row.typed_action.as_ref()?;
+    if expanded {
+        action.is_complete().then_some(("Approve", "Deny"))
+    } else {
+        action
+            .direct_approval_allowed_in_compact()
+            .then_some(("Approve", "Deny"))
+    }
+}
+
+fn rosetta_agent_label(row: &RosettaRow) -> &'static str {
+    row.tool.map(|tool| tool.display_name()).unwrap_or("Agent")
+}
+
+fn rosetta_row_title(row: &RosettaRow) -> String {
+    row.thread_title
+        .as_ref()
+        .or(row.workspace_title.as_ref())
+        .or(row.context.as_ref())
+        .cloned()
+        .unwrap_or_else(|| rosetta_agent_label(row).to_string())
+}
+
+fn rosetta_row_context(row: &RosettaRow) -> Option<String> {
+    let title = rosetta_row_title(row);
+    row.context
+        .as_ref()
+        .filter(|context| context.as_str() != title)
+        .cloned()
+        .or_else(|| {
+            row.workspace_title
+                .as_ref()
+                .filter(|workspace| workspace.as_str() != title)
+                .cloned()
+        })
+}
+
+fn rosetta_row_detail(row: &RosettaRow) -> Option<String> {
+    row.message
+        .as_ref()
+        .filter(|message| !message.trim().is_empty())
+        .cloned()
+        .or_else(|| {
+            row.last_result
+                .as_ref()
+                .filter(|result| !result.trim().is_empty())
+                .cloned()
+        })
+        .or_else(|| {
+            row.active_tool_name
+                .as_ref()
+                .filter(|tool| !tool.trim().is_empty())
+                .map(|tool| format!("Using {tool}"))
+        })
+        .or_else(|| {
+            (row.state == RosettaRowState::WaitingForInput)
+                .then(|| "Needs your response".to_string())
+        })
+}
+
+fn rosetta_row_time(row: &RosettaRow) -> Option<String> {
+    if let Some(secs) = row.waiting_secs {
+        return Some(rosetta_duration_label(secs));
+    }
+    row.last_activity_secs.map(rosetta_duration_label)
+}
+
+pub(crate) fn rosetta_duration_label(secs: u64) -> String {
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3_600 {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{}h {}m", secs / 3_600, (secs % 3_600) / 60)
+    }
+}
+
+fn rosetta_status_indicator(
+    row_state: RosettaRowState,
+    ui: crate::theme::UiColors,
+    animation_id: SharedString,
+) -> AnyElement {
+    let spinner_color = rgb(0xD29922);
+    let slot = div()
+        .flex_none()
+        .w(px(14.))
+        .h(px(14.))
+        .flex()
+        .items_center()
+        .justify_center();
+
+    match row_state {
+        RosettaRowState::Thinking => slot
+            .child(
+                svg()
+                    .size(px(13.))
+                    .flex_none()
+                    .path("icons/loader-circle.svg")
+                    .text_color(spinner_color)
+                    .with_animation(
+                        SharedString::from(format!("{animation_id}-spinner")),
+                        Animation::new(Duration::from_secs(1)).repeat(),
+                        |svg, delta| {
+                            svg.with_transformation(Transformation::rotate(percentage(delta)))
+                        },
+                    ),
+            )
+            .into_any_element(),
+        RosettaRowState::Finished => slot
+            .child(
+                div()
+                    .w(px(14.))
+                    .h(px(14.))
+                    .rounded_full()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .bg(rgb(0x3FB950))
+                    .child(
+                        svg()
+                            .size(px(9.))
+                            .flex_none()
+                            .path("icons/check.svg")
+                            .text_color(ui.base),
+                    ),
+            )
+            .into_any_element(),
+        _ => slot
+            .child(
+                div()
+                    .w(px(7.))
+                    .h(px(7.))
+                    .rounded_full()
+                    .bg(rosetta_status_color(row_state, ui)),
+            )
+            .into_any_element(),
+    }
+}
+
+fn render_rosetta_empty_state(ui: crate::theme::UiColors) -> AnyElement {
+    div()
+        .min_h(px(168.))
+        .flex()
+        .items_center()
+        .justify_center()
+        .px(px(24.))
+        .py(px(28.))
+        .text_center()
+        .text_size(px(12.))
+        .text_color(ui.muted)
+        .child("No active Rosetta items")
+        .into_any_element()
+}
+
+fn rosetta_label_chip(label: &'static str, ui: crate::theme::UiColors) -> AnyElement {
+    div()
+        .flex_none()
+        .px(px(7.))
+        .py(px(2.))
+        .rounded(px(6.))
+        .bg(with_alpha(ui.text, 0.08))
+        .text_size(px(10.))
+        .text_color(ui.text)
+        .child(label)
+        .into_any_element()
+}
+
+fn rosetta_attention_badge(ui: crate::theme::UiColors) -> AnyElement {
+    div()
+        .flex_none()
+        .px(px(6.))
+        .py(px(1.))
+        .rounded(px(5.))
+        .bg(rgb(0xFBBF24))
+        .text_size(px(10.))
+        .font_weight(gpui::FontWeight::SEMIBOLD)
+        .text_color(ui.base)
+        .child("Needs response")
+        .into_any_element()
+}
+
+fn rosetta_text_button(
+    label: &'static str,
+    ui: crate::theme::UiColors,
+) -> gpui::Stateful<gpui::Div> {
+    div()
+        .id(SharedString::from(format!("rosetta-action-{label}")))
+        .occlude()
+        .px(px(6.))
+        .py(px(2.))
+        .rounded(px(6.))
+        .text_size(px(10.))
+        .text_color(ui.muted)
+        .bg(with_alpha(ui.text, 0.06))
+        .cursor_pointer()
+        .hover(|s| s.bg(with_alpha(ui.text, 0.10)).text_color(ui.text))
+        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+        .on_mouse_down(MouseButton::Right, |_, _, cx| cx.stop_propagation())
+        .child(label)
+}
+
+fn rosetta_status_color(state: RosettaRowState, ui: crate::theme::UiColors) -> gpui::Hsla {
+    match state {
+        RosettaRowState::WaitingForInput => ui.vc_conflict,
+        RosettaRowState::Errored => ui.agent_error,
+        RosettaRowState::Stalled => ui.agent_stalled,
+        RosettaRowState::Thinking => ui.accent,
+        RosettaRowState::Finished => ui.vc_added,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paneflow_acp::AgentKind;
+
+    fn session(
+        state: AgentState,
+        surface_id: Option<u64>,
+        now: Instant,
+        waiting_secs: Option<u64>,
+        last_activity_secs: u64,
+    ) -> AgentSession {
+        let mut session = AgentSession::new(TerminalAgent::ClaudeCode, state);
+        session.surface_id = surface_id;
+        session.waiting_since = waiting_secs.map(|secs| now - Duration::from_secs(secs));
+        session.last_activity = now - Duration::from_secs(last_activity_secs);
+        session
+    }
+
+    fn source<'a>(
+        workspace_id: u64,
+        workspace_title: &'a str,
+        pid: u32,
+        session: &'a AgentSession,
+    ) -> WorkspaceSessionRef<'a> {
+        WorkspaceSessionRef {
+            workspace_id,
+            workspace_title,
+            pid,
+            session,
+        }
+    }
+
+    fn projection_from_sessions(
+        sessions: &[WorkspaceSessionRef<'_>],
+        now: Instant,
+    ) -> RosettaProjection {
+        build_rosetta_projection_from_parts(
+            sessions,
+            &[],
+            &[],
+            &RosettaRecentHistory::default(),
+            now,
+        )
+    }
+
+    fn sample_row(state: RosettaRowState, title: &str, waiting_secs: Option<u64>) -> RosettaRow {
+        RosettaRow {
+            source: RosettaRowSource::RecentEvent { sequence: 1 },
+            state,
+            tool: Some(TerminalAgent::Codex),
+            workspace_title: Some(title.to_string()),
+            thread_title: None,
+            context: None,
+            surface_id: None,
+            focus_target: None,
+            message: Some("status detail".to_string()),
+            waiting_secs,
+            last_activity_secs: Some(3),
+            active_tool_name: None,
+            last_result: None,
+            typed_action: None,
+            sort_order: 0,
+        }
+    }
+
+    #[test]
+    fn empty_projection_returns_no_rows() {
+        let projection = build_rosetta_projection_from_parts(
+            &[],
+            &[],
+            &[],
+            &RosettaRecentHistory::default(),
+            Instant::now(),
+        );
+
+        assert!(projection.is_empty());
+    }
+
+    #[test]
+    fn workspace_session_rows_include_available_fields() {
+        let now = Instant::now();
+        let mut session = session(AgentState::WaitingForInput, Some(77), now, Some(42), 9);
+        session.message = Some("Allow cargo test?".to_string());
+        session.active_tool_name = Some("Bash".to_string());
+        session.last_result = Some("Tests are green".to_string());
+
+        let sources = [source(3, "backend", 1234, &session)];
+        let projection = projection_from_sessions(&sources, now);
+        let row = &projection.rows[0];
+
+        assert_eq!(row.tool, Some(TerminalAgent::ClaudeCode));
+        assert_eq!(row.state, RosettaRowState::WaitingForInput);
+        assert_eq!(row.workspace_title.as_deref(), Some("backend"));
+        assert_eq!(row.surface_id, Some(77));
+        assert_eq!(row.message.as_deref(), Some("Allow cargo test?"));
+        assert_eq!(row.waiting_secs, Some(42));
+        assert_eq!(row.last_activity_secs, Some(9));
+        assert_eq!(row.active_tool_name.as_deref(), Some("Bash"));
+        assert_eq!(row.last_result.as_deref(), Some("Tests are green"));
+        assert_eq!(
+            row.focus_target,
+            Some(RosettaFocusTarget::WorkspaceSurface {
+                workspace_id: 3,
+                surface_id: 77
+            })
+        );
+    }
+
+    #[test]
+    fn unresolved_workspace_session_stays_visible_without_focus_target() {
+        let now = Instant::now();
+        let session = session(AgentState::Thinking, None, now, None, 1);
+        let sources = [source(3, "unresolved", 1, &session)];
+        let projection = projection_from_sessions(&sources, now);
+
+        assert_eq!(projection.rows.len(), 1);
+        assert_eq!(projection.rows[0].surface_id, None);
+        assert_eq!(projection.rows[0].focus_target, None);
+    }
+
+    #[test]
+    fn rows_rank_by_rosetta_salience() {
+        let now = Instant::now();
+        let finished = session(AgentState::Finished, Some(1), now, None, 1);
+        let thinking = session(AgentState::Thinking, Some(2), now, None, 1);
+        let stalled = session(AgentState::Stalled, Some(3), now, None, 1);
+        let waiting = session(AgentState::WaitingForInput, Some(4), now, Some(5), 1);
+        let errored = session(AgentState::Errored, Some(5), now, None, 1);
+        let sources = [
+            source(1, "w", 1, &finished),
+            source(1, "w", 2, &thinking),
+            source(1, "w", 3, &stalled),
+            source(1, "w", 4, &waiting),
+            source(1, "w", 5, &errored),
+        ];
+
+        let states: Vec<_> = projection_from_sessions(&sources, now)
+            .rows
+            .iter()
+            .map(|row| row.state)
+            .collect();
+
+        assert_eq!(
+            states,
+            vec![
+                RosettaRowState::Errored,
+                RosettaRowState::WaitingForInput,
+                RosettaRowState::Stalled,
+                RosettaRowState::Thinking,
+                RosettaRowState::Finished,
+            ]
+        );
+    }
+
+    #[test]
+    fn waiting_rows_tie_break_by_longest_wait() {
+        let now = Instant::now();
+        let younger = session(AgentState::WaitingForInput, Some(1), now, Some(10), 1);
+        let older = session(AgentState::WaitingForInput, Some(2), now, Some(90), 1);
+        let sources = [source(1, "w", 1, &younger), source(1, "w", 2, &older)];
+
+        let projection = projection_from_sessions(&sources, now);
+
+        assert_eq!(projection.rows[0].surface_id, Some(2));
+        assert_eq!(projection.rows[0].waiting_secs, Some(90));
+    }
+
+    #[test]
+    fn rosetta_sections_use_prd_order() {
+        let rows = vec![
+            sample_row(RosettaRowState::Thinking, "running", None),
+            sample_row(RosettaRowState::Finished, "done", None),
+            sample_row(RosettaRowState::WaitingForInput, "waiting", Some(120)),
+            sample_row(RosettaRowState::Errored, "failed", None),
+            sample_row(RosettaRowState::Stalled, "stalled", None),
+        ];
+
+        let kinds: Vec<_> = rosetta_sections(&rows)
+            .into_iter()
+            .map(|section| section.kind)
+            .collect();
+
+        assert_eq!(
+            kinds,
+            vec![
+                RosettaSectionKind::NeedsInput,
+                RosettaSectionKind::Failed,
+                RosettaSectionKind::Stalled,
+                RosettaSectionKind::Running,
+                RosettaSectionKind::Recent,
+            ]
+        );
+    }
+
+    #[test]
+    fn compact_summary_for_passive_running_is_single_line() {
+        let rows = vec![
+            sample_row(RosettaRowState::Thinking, "one", None),
+            sample_row(RosettaRowState::Thinking, "two", None),
+        ];
+
+        let summary = rosetta_compact_summary(&rows).expect("summary");
+
+        assert_eq!(summary.label, "running");
+        assert_eq!(summary.title, "2 running");
+        assert_eq!(summary.detail, None);
+        assert!(summary.passive_only);
+    }
+
+    #[test]
+    fn rosetta_duration_labels_are_compact() {
+        assert_eq!(rosetta_duration_label(9), "9s");
+        assert_eq!(rosetta_duration_label(60), "1m");
+        assert_eq!(rosetta_duration_label(3_660), "1h 1m");
+    }
+
+    #[test]
+    fn waiting_rows_render_reply_not_direct_approval_from_freeform_text() {
+        let row = sample_row(RosettaRowState::WaitingForInput, "waiting", Some(20));
+
+        assert_eq!(
+            rosetta_primary_action_label(&row, RosettaTargetStatus::Navigable),
+            "Reply"
+        );
+        assert_eq!(rosetta_direct_approval_controls(&row, true), None);
+    }
+
+    #[test]
+    fn waiting_rows_fallback_to_needs_response_copy() {
+        let mut row = sample_row(RosettaRowState::WaitingForInput, "waiting", Some(20));
+        row.message = None;
+
+        assert_eq!(rosetta_state_label(row.state), "needs response");
+        assert_eq!(rosetta_plural_subject(row.state), "need responses");
+        assert_eq!(
+            rosetta_row_detail(&row).as_deref(),
+            Some("Needs your response")
+        );
+    }
+
+    #[test]
+    fn agent_text_is_plain_sanitized_and_capped() {
+        let raw = format!(
+            "**Approve** [link](https://example.com) \x1b[31mred\x1b[0m \
+             \x1b]8;;https://example.com\u{0007}linked\x1b]8;;\u{0007} \
+             \u{202E}\u{200B}\u{0008}\u{0085}{}",
+            "x".repeat(600)
+        );
+
+        let text = cap_agent_text(&raw);
+
+        assert!(text.contains("**Approve**"));
+        assert!(text.contains("[link](https://example.com)"));
+        assert!(text.contains("red"));
+        assert!(!text.contains("\x1b"));
+        assert!(!text.contains("[31m"));
+        assert!(!text.contains("\u{202E}"));
+        assert!(!text.contains("\u{200B}"));
+        assert!(!text.chars().any(|c| {
+            matches!(
+                c,
+                '\u{0000}'..='\u{001f}' | '\u{007f}' | '\u{0080}'..='\u{009f}'
+            )
+        }));
+        assert_eq!(text.chars().count(), ROSETTA_AGENT_TEXT_CAP_CHARS);
+        assert!(text.ends_with("..."));
+    }
+
+    #[test]
+    fn workspace_rows_sanitize_message_and_last_result() {
+        let now = Instant::now();
+        let mut session = session(AgentState::Errored, Some(77), now, None, 1);
+        session.message = Some("\x1b[32mClick Approve\u{202E}".to_string());
+        session.last_result = Some(format!("{}\x1b[0m", "r".repeat(600)));
+        session.active_tool_name = Some("Bash\x1b[31m\u{202E}".to_string());
+
+        let sources = [source(3, "backend", 1234, &session)];
+        let projection = projection_from_sessions(&sources, now);
+        let row = &projection.rows[0];
+
+        assert_eq!(row.message.as_deref(), Some("Click Approve"));
+        assert_eq!(row.active_tool_name.as_deref(), Some("Bash"));
+        assert_eq!(
+            row.last_result
+                .as_deref()
+                .map(str::chars)
+                .map(Iterator::count),
+            Some(ROSETTA_AGENT_TEXT_CAP_CHARS)
+        );
+        assert!(!row.last_result.as_deref().unwrap_or("").contains("\x1b"));
+    }
+
+    #[test]
+    fn typed_approval_requires_complete_metadata_and_compact_risk_gate() {
+        let mut row = sample_row(RosettaRowState::WaitingForInput, "waiting", Some(20));
+        row.typed_action = Some(RosettaTypedAction {
+            action_id: Some("approve-1".to_string()),
+            command: Some("cargo test".to_string()),
+            cwd: Some("C:/dev/paneflow-rosetta".to_string()),
+            tool: Some(TerminalAgent::Codex),
+            risk: RosettaActionRisk::Low,
+        });
+
+        assert_eq!(
+            rosetta_direct_approval_controls(&row, false),
+            Some(("Approve", "Deny"))
+        );
+
+        row.typed_action.as_mut().expect("typed action").risk = RosettaActionRisk::Network;
+        assert_eq!(rosetta_direct_approval_controls(&row, false), None);
+        assert_eq!(
+            rosetta_direct_approval_controls(&row, true),
+            Some(("Approve", "Deny"))
+        );
+
+        row.typed_action.as_mut().expect("typed action").risk = RosettaActionRisk::Low;
+        row.typed_action.as_mut().expect("typed action").command =
+            Some("x".repeat(ROSETTA_TYPED_ACTION_COMPACT_COMMAND_CHARS + 1));
+        assert_eq!(rosetta_direct_approval_controls(&row, false), None);
+        assert_eq!(
+            rosetta_direct_approval_controls(&row, true),
+            Some(("Approve", "Deny"))
+        );
+
+        row.typed_action.as_mut().expect("typed action").action_id = None;
+        assert_eq!(rosetta_direct_approval_controls(&row, true), None);
+    }
+
+    #[test]
+    fn incomplete_typed_action_falls_back_to_open() {
+        let mut row = sample_row(RosettaRowState::Thinking, "running", None);
+        row.typed_action = Some(RosettaTypedAction {
+            action_id: Some("approve-1".to_string()),
+            command: Some("cargo test".to_string()),
+            cwd: None,
+            tool: Some(TerminalAgent::Codex),
+            risk: RosettaActionRisk::Low,
+        });
+
+        assert_eq!(rosetta_direct_approval_controls(&row, true), None);
+        assert_eq!(
+            rosetta_primary_action_label(&row, RosettaTargetStatus::Navigable),
+            "Open"
+        );
+    }
+
+    #[test]
+    fn compact_rows_demote_snoozed_waiting_but_keep_expanded_row_available() {
+        let mut waiting = sample_row(RosettaRowState::WaitingForInput, "waiting", Some(300));
+        waiting.source = RosettaRowSource::RecentEvent { sequence: 1 };
+        let mut running = sample_row(RosettaRowState::Thinking, "running", None);
+        running.source = RosettaRowSource::RecentEvent { sequence: 2 };
+        let waiting_key = waiting.key();
+        let rows = vec![waiting, running];
+        let snoozed = HashSet::from([waiting_key]);
+        let compact = rosetta_compact_rows(&rows, &snoozed, &HashSet::new(), &HashSet::new());
+
+        assert_eq!(compact[0].state, RosettaRowState::Thinking);
+        assert!(rows.iter().any(|row| row.key() == waiting_key));
+    }
+
+    #[test]
+    fn dismissed_error_sinks_from_compact_without_removing_expanded_row() {
+        let mut error = sample_row(RosettaRowState::Errored, "failed", None);
+        error.source = RosettaRowSource::RecentEvent { sequence: 1 };
+        let mut running = sample_row(RosettaRowState::Thinking, "running", None);
+        running.source = RosettaRowSource::RecentEvent { sequence: 2 };
+        let error_key = error.key();
+        let rows = vec![error, running];
+        let dismissed = HashSet::from([error_key]);
+        let compact = rosetta_compact_rows(&rows, &HashSet::new(), &dismissed, &HashSet::new());
+
+        assert_eq!(compact[0].state, RosettaRowState::Thinking);
+        assert!(rows.iter().any(|row| row.key() == error_key));
+    }
+
+    #[test]
+    fn read_recent_rows_leave_expanded_projection_but_leave_compact() {
+        let mut finished = sample_row(RosettaRowState::Finished, "done", None);
+        finished.source = RosettaRowSource::RecentEvent { sequence: 1 };
+        let finished_key = finished.key();
+        let mut running = sample_row(RosettaRowState::Thinking, "running", None);
+        running.source = RosettaRowSource::RecentEvent { sequence: 2 };
+        let rows = vec![finished, running];
+        let read = HashSet::from([finished_key]);
+        let compact = rosetta_compact_rows(&rows, &HashSet::new(), &HashSet::new(), &read);
+
+        assert_eq!(compact.len(), 1);
+        assert_eq!(compact[0].state, RosettaRowState::Thinking);
+        assert!(rows.iter().any(|row| row.key() == finished_key));
+    }
+
+    #[test]
+    fn recent_history_can_dismiss_finished_event_by_sequence() {
+        let now = Instant::now();
+        let mut history = RosettaRecentHistory::default();
+        history.push(RosettaRecentEvent::new(RosettaRowState::Finished, now));
+        let projection = build_rosetta_projection_from_parts(&[], &[], &[], &history, now);
+        let sequence = match projection.rows[0].source {
+            RosettaRowSource::RecentEvent { sequence } => sequence,
+            _ => unreachable!("projection row should be recent"),
+        };
+
+        assert!(history.dismiss_sequence(sequence));
+        assert!(history.visible_events(now).next().is_none());
+    }
+
+    #[test]
+    fn agents_threads_project_waiting_rows_include_context_and_target() {
+        let mut project = Project::new("paneflow-web", "C:/dev/paneflow-web");
+        let mut thread =
+            Thread::new_terminal("Codex polish", &project.cwd, Some(TerminalAgent::Codex));
+        thread.status = ThreadStatus::WaitingForInput;
+        let thread_id = thread.id;
+        project.threads.push(thread);
+
+        let projection = build_rosetta_projection_from_parts(
+            &[],
+            &[project],
+            &[],
+            &RosettaRecentHistory::default(),
+            Instant::now(),
+        );
+        let row = &projection.rows[0];
+
+        assert_eq!(row.state, RosettaRowState::WaitingForInput);
+        assert_eq!(row.tool, Some(TerminalAgent::Codex));
+        assert_eq!(row.thread_title.as_deref(), Some("Codex polish"));
+        assert_eq!(row.context.as_deref(), Some("paneflow-web"));
+        assert_eq!(
+            row.focus_target,
+            Some(RosettaFocusTarget::AgentsThread(AgentsTarget::Thread {
+                project_idx: 0,
+                thread_idx: 0,
+            }))
+        );
+        assert_eq!(
+            row.source,
+            RosettaRowSource::AgentsThread {
+                target: AgentsTarget::Thread {
+                    project_idx: 0,
+                    thread_idx: 0,
+                },
+                thread_id,
+            }
+        );
+    }
+
+    #[test]
+    fn agents_thread_failed_ranks_above_waiting_and_thinking() {
+        let mut project = Project::new("p", "/tmp");
+        let mut thinking = Thread::new_terminal("thinking", &project.cwd, None);
+        thinking.status = ThreadStatus::Thinking;
+        let mut waiting = Thread::new_terminal("waiting", &project.cwd, None);
+        waiting.status = ThreadStatus::WaitingForInput;
+        let mut failed = Thread::new_terminal("failed", &project.cwd, None);
+        failed.status = ThreadStatus::Failed;
+        project.threads = vec![thinking, waiting, failed];
+
+        let states: Vec<_> = build_rosetta_projection_from_parts(
+            &[],
+            &[project],
+            &[],
+            &RosettaRecentHistory::default(),
+            Instant::now(),
+        )
+        .rows
+        .iter()
+        .map(|row| row.state)
+        .collect();
+
+        assert_eq!(
+            states,
+            vec![
+                RosettaRowState::Errored,
+                RosettaRowState::WaitingForInput,
+                RosettaRowState::Thinking,
+            ]
+        );
+    }
+
+    #[test]
+    fn idle_agents_threads_are_omitted() {
+        let mut project = Project::new("p", "/tmp");
+        project
+            .threads
+            .push(Thread::new_terminal("idle", &project.cwd, None));
+
+        let projection = build_rosetta_projection_from_parts(
+            &[],
+            &[project],
+            &[],
+            &RosettaRecentHistory::default(),
+            Instant::now(),
+        );
+
+        assert!(projection.rows.is_empty());
+    }
+
+    #[test]
+    fn stalled_is_not_fabricated_from_agents_thread_status() {
+        assert_eq!(
+            RosettaRowState::from_thread_status(ThreadStatus::Thinking),
+            Some(RosettaRowState::Thinking)
+        );
+        assert_eq!(
+            ThreadStatus::from_agent_state(AgentState::Stalled),
+            ThreadStatus::Thinking
+        );
+    }
+
+    #[test]
+    fn chats_are_projected_with_chat_context() {
+        let mut chat =
+            Thread::new_terminal("Ask Codex", "C:/Users/Arthur", Some(TerminalAgent::Codex));
+        chat.status = ThreadStatus::Thinking;
+
+        let projection = build_rosetta_projection_from_parts(
+            &[],
+            &[],
+            &[chat],
+            &RosettaRecentHistory::default(),
+            Instant::now(),
+        );
+
+        assert_eq!(projection.rows[0].context.as_deref(), Some("Chat"));
+        assert_eq!(
+            projection.rows[0].focus_target,
+            Some(RosettaFocusTarget::AgentsThread(AgentsTarget::Chat {
+                chat_idx: 0
+            }))
+        );
+    }
+
+    #[test]
+    fn recent_history_starts_empty() {
+        let history = RosettaRecentHistory::default();
+
+        assert_eq!(history.len(), 0);
+        assert!(history.visible_events(Instant::now()).next().is_none());
+    }
+
+    #[test]
+    fn recent_history_caps_message_and_rows() {
+        let now = Instant::now();
+        let mut history = RosettaRecentHistory::default();
+
+        for idx in 0..30 {
+            let mut event =
+                RosettaRecentEvent::new(RosettaRowState::Finished, now - Duration::from_secs(idx));
+            event.message = Some("x".repeat(600));
+            history.push(event);
+        }
+
+        assert_eq!(history.len(), ROSETTA_RECENT_EVENT_CAP);
+        let projection = build_rosetta_projection_from_parts(&[], &[], &[], &history, now);
+
+        assert_eq!(projection.rows.len(), ROSETTA_RECENT_EVENT_CAP);
+        assert_eq!(
+            projection.rows[0]
+                .message
+                .as_deref()
+                .map(str::chars)
+                .map(Iterator::count),
+            Some(ROSETTA_AGENT_TEXT_CAP_CHARS)
+        );
+        assert_eq!(
+            projection
+                .rows
+                .iter()
+                .filter_map(|row| match row.source {
+                    RosettaRowSource::RecentEvent { sequence } => Some(sequence),
+                    _ => None,
+                })
+                .min(),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn recent_history_omits_events_after_retention_window() {
+        let now = Instant::now();
+        let mut history = RosettaRecentHistory::default();
+        history.push(RosettaRecentEvent::new(
+            RosettaRowState::Finished,
+            now - ROSETTA_RECENT_EVENT_RETENTION - Duration::from_secs(1),
+        ));
+        history.push(RosettaRecentEvent::new(
+            RosettaRowState::Finished,
+            now - Duration::from_secs(10),
+        ));
+
+        let projection = build_rosetta_projection_from_parts(&[], &[], &[], &history, now);
+
+        assert_eq!(projection.rows.len(), 1);
+    }
+
+    #[test]
+    fn workspace_recent_event_snapshots_session_fields_and_caps_on_push() {
+        let now = Instant::now();
+        let mut session = session(AgentState::Finished, Some(77), now, None, 3);
+        session.last_result = Some("x".repeat(600));
+
+        let mut history = RosettaRecentHistory::default();
+        history.push(rosetta_recent_event_from_workspace_session(
+            3,
+            "backend",
+            &session,
+            RosettaRowState::Finished,
+            now,
+        ));
+        let projection = build_rosetta_projection_from_parts(&[], &[], &[], &history, now);
+        let row = &projection.rows[0];
+
+        assert_eq!(row.state, RosettaRowState::Finished);
+        assert_eq!(row.workspace_title.as_deref(), Some("backend"));
+        assert_eq!(row.surface_id, Some(77));
+        assert_eq!(
+            row.focus_target,
+            Some(RosettaFocusTarget::WorkspaceSurface {
+                workspace_id: 3,
+                surface_id: 77
+            })
+        );
+        assert_eq!(
+            row.last_result
+                .as_deref()
+                .map(str::chars)
+                .map(Iterator::count),
+            Some(ROSETTA_AGENT_TEXT_CAP_CHARS)
+        );
+    }
+
+    #[test]
+    fn agents_recent_event_snapshots_thread_context_and_target() {
+        let now = Instant::now();
+        let thread = Thread::new_terminal(
+            "Codex polish",
+            "C:/dev/paneflow",
+            Some(TerminalAgent::Codex),
+        );
+        let target = AgentsTarget::Thread {
+            project_idx: 2,
+            thread_idx: 4,
+        };
+
+        let event = rosetta_recent_event_from_agents_thread(
+            &thread,
+            target,
+            Some("paneflow"),
+            RosettaRowState::Finished,
+            now,
+        );
+
+        assert_eq!(event.state, RosettaRowState::Finished);
+        assert_eq!(event.tool, Some(TerminalAgent::Codex));
+        assert_eq!(event.thread_title.as_deref(), Some("Codex polish"));
+        assert_eq!(event.context.as_deref(), Some("paneflow"));
+        assert_eq!(
+            event.focus_target,
+            Some(RosettaFocusTarget::AgentsThread(target))
+        );
+    }
+
+    #[test]
+    fn thread_tool_falls_back_to_legacy_agent_kind() {
+        let thread = Thread::new("legacy", AgentKind::Codex, "/tmp");
+
+        assert_eq!(thread_tool(&thread), TerminalAgent::Codex);
+    }
+}

--- a/src-app/src/app/settings.rs
+++ b/src-app/src/app/settings.rs
@@ -89,6 +89,9 @@ impl PaneFlowApp {
     ) {
         self.cached_config =
             config_writer::with_field(&self.cached_config, nested, key, value.clone());
+        if key.starts_with("rosetta_") {
+            self.sync_rosetta_config_state();
+        }
         cx.notify();
         cx.background_spawn(async move {
             smol::unblock(move || {

--- a/src-app/src/app/sidebar_actions_menu.rs
+++ b/src-app/src/app/sidebar_actions_menu.rs
@@ -18,6 +18,9 @@ use crate::PaneFlowApp;
 use crate::settings::components::{select_item, select_menu_surface, with_alpha};
 use crate::window_chrome::title_bar::{SelfUpdatePillState, SystemPackageKind, UpdatePillKind};
 
+const SIDEBAR_UPDATE_SHIMMER_MS: u64 = 2600;
+const SIDEBAR_UPDATE_IRIS_COLORS: [u32; 5] = [0x2f6fff, 0x1da8ff, 0x8ea7ff, 0xb68cff, 0xf2f7ff];
+
 impl PaneFlowApp {
     /// Update CTA banner at the bottom of the sidebar, above the Settings
     /// trigger. Replaces the title-bar update pill in the cockpit modes
@@ -59,6 +62,12 @@ impl PaneFlowApp {
             UpdatePillKind::InApp(SelfUpdatePillState::Idle | SelfUpdatePillState::Errored)
                 | UpdatePillKind::SystemManaged(_)
         );
+        let label_element = if matches!(info.kind, UpdatePillKind::InApp(SelfUpdatePillState::Idle))
+        {
+            render_update_available_label(&format!("v{}", info.version), ui)
+        } else {
+            render_update_plain_label(&label, ui)
+        };
 
         let leading_icon: AnyElement = if busy {
             svg()
@@ -91,27 +100,16 @@ impl PaneFlowApp {
             .id("sidebar-update-banner")
             .mx(px(6.))
             .mb(px(2.))
+            .h(px(30.))
             .px(px(8.))
-            .py(px(6.))
-            .rounded(px(6.))
-            .border_1()
-            .border_color(ui.border)
-            .bg(ui.subtle)
+            .rounded(crate::app::constants::SIDEBAR_TAB_CORNER_RADIUS)
+            .bg(crate::app::constants::sidebar_tab_active_background())
             .flex()
             .flex_row()
             .items_center()
             .gap(px(6.))
             .child(leading_icon)
-            .child(
-                div()
-                    .flex_1()
-                    .min_w_0()
-                    .text_color(ui.text)
-                    .text_size(px(12.))
-                    .font_weight(FontWeight::MEDIUM)
-                    .truncate()
-                    .child(label),
-            );
+            .child(label_element);
 
         if dismissable {
             let muted = ui.muted;
@@ -145,8 +143,7 @@ impl PaneFlowApp {
                 .cursor_pointer()
                 .when(system_hint, |d| d.opacity(0.8))
                 .hover(move |s| {
-                    let ui = crate::theme::ui_colors();
-                    let s = s.bg(ui.surface).border_color(ui.muted);
+                    let s = s.bg(crate::app::constants::sidebar_tab_hover_background());
                     if system_hint { s.opacity(1.0) } else { s }
                 })
                 .on_mouse_down(MouseButton::Left, move |_, window, cx| {
@@ -433,4 +430,100 @@ fn render_menu_item(
                 .child(item.label),
         )
         .into_any_element()
+}
+
+fn render_update_available_label(version: &str, ui: crate::theme::UiColors) -> AnyElement {
+    div()
+        .flex_1()
+        .min_w_0()
+        .text_size(px(12.))
+        .font_weight(FontWeight::BOLD)
+        .truncate()
+        .flex()
+        .flex_row()
+        .child(render_update_shimmer_text(
+            version,
+            gpui::Hsla::from(gpui::rgb(SIDEBAR_UPDATE_IRIS_COLORS[2])).opacity(0.88),
+        ))
+        .child(div().text_color(ui.text).child(" available"))
+        .into_any_element()
+}
+
+fn render_update_plain_label(label: &str, ui: crate::theme::UiColors) -> AnyElement {
+    div()
+        .flex_1()
+        .min_w_0()
+        .text_size(px(12.))
+        .font_weight(FontWeight::BOLD)
+        .text_color(ui.text)
+        .truncate()
+        .child(label.to_string())
+        .into_any_element()
+}
+
+fn render_update_shimmer_text(label: &str, base_color: gpui::Hsla) -> AnyElement {
+    let letter_count = label.chars().count() as f32;
+
+    div()
+        .flex()
+        .flex_row()
+        .children(label.chars().enumerate().map(|(index, ch)| {
+            div()
+                .text_color(base_color)
+                .child(ch.to_string())
+                .with_animation(
+                    SharedString::from(format!("sidebar-update-shimmer-letter-{index}")),
+                    Animation::new(Duration::from_millis(SIDEBAR_UPDATE_SHIMMER_MS)).repeat(),
+                    move |letter, delta| {
+                        letter.text_color(update_shimmer_color(
+                            base_color,
+                            index,
+                            letter_count,
+                            delta,
+                        ))
+                    },
+                )
+                .into_any_element()
+        }))
+        .into_any_element()
+}
+
+fn update_shimmer_color(
+    base_color: gpui::Hsla,
+    index: usize,
+    letter_count: f32,
+    delta: f32,
+) -> gpui::Hsla {
+    let width = letter_count.max(1.);
+    let letter_phase = index as f32 / width;
+    let phase = (delta + letter_phase * 0.32).fract();
+    let iris_color = update_iris_color_at(phase);
+    let highlight = ((phase * std::f32::consts::TAU).sin() + 1.) * 0.5;
+    let hue = lerp(base_color.h, iris_color.h, 0.92);
+    let saturation = lerp(base_color.s, iris_color.s, 0.9);
+    let lightness = (lerp(base_color.l, iris_color.l, 0.9) + highlight * 0.035).min(0.94);
+    let alpha = lerp(base_color.a, 0.98, 0.86);
+
+    gpui::hsla(hue, saturation, lightness, alpha)
+}
+
+fn update_iris_color_at(phase: f32) -> gpui::Hsla {
+    let palette_len = SIDEBAR_UPDATE_IRIS_COLORS.len();
+    let scaled = phase * palette_len as f32;
+    let start = scaled.floor() as usize % palette_len;
+    let end = (start + 1) % palette_len;
+    let amount = scaled.fract();
+    let a = gpui::Hsla::from(gpui::rgb(SIDEBAR_UPDATE_IRIS_COLORS[start]));
+    let b = gpui::Hsla::from(gpui::rgb(SIDEBAR_UPDATE_IRIS_COLORS[end]));
+
+    gpui::hsla(
+        lerp(a.h, b.h, amount),
+        lerp(a.s, b.s, amount),
+        lerp(a.l, b.l, amount),
+        lerp(a.a, b.a, amount),
+    )
+}
+
+fn lerp(from: f32, to: f32, amount: f32) -> f32 {
+    from + (to - from) * amount
 }

--- a/src-app/src/main.rs
+++ b/src-app/src/main.rs
@@ -806,6 +806,26 @@ struct PaneFlowApp {
     attention_queue_open: bool,
     attention_queue_selected: usize,
     attention_queue_focus: FocusHandle,
+    /// EP-001 (Rosetta): volatile recent done/error/wait events. Starts empty
+    /// on every app launch and never writes to disk; live rows are still
+    /// derived from workspace/session/thread truth.
+    rosetta_recent_history: app::rosetta::RosettaRecentHistory,
+    /// EP-002 (Rosetta): top-center surface UI state. Rows stay derived live;
+    /// this only tracks the user's expanded/cursor state for the current frame.
+    rosetta_surface_expanded: bool,
+    rosetta_surface_selected: usize,
+    rosetta_surface_selected_key: Option<app::rosetta::RosettaRowKey>,
+    rosetta_surface_focus: FocusHandle,
+    rosetta_surface_scroll: gpui::ScrollHandle,
+    rosetta_surface_pending_focus: bool,
+    /// EP-003 (Rosetta): volatile row-level noise controls. Snoozes reduce
+    /// compact urgency until expiry; dismissed error rows stay available in the
+    /// expanded panel while they exist in live app state.
+    rosetta_snoozed_rows:
+        std::collections::HashMap<app::rosetta::RosettaRowKey, std::time::Instant>,
+    rosetta_dismissed_rows: std::collections::HashSet<app::rosetta::RosettaRowKey>,
+    rosetta_read_rows: std::collections::HashSet<app::rosetta::RosettaRowKey>,
+    rosetta_passive_display_enabled: bool,
     /// EP-006 US-018 (cli-cockpit): fleet-grep overlay state, `None` =
     /// closed. Results are a bounded snapshot (counts + names, never the
     /// match vectors); the fan-out is generation-guarded.
@@ -1232,6 +1252,7 @@ impl Render for PaneFlowApp {
                 )
                 .into_any_element()
         };
+        let rosetta_surface = self.render_rosetta_surface(window, cx);
 
         // Update title bar with current workspace name. US-010: in Agents
         // mode the brand slot carries the thread/chat context instead, so the
@@ -1264,6 +1285,7 @@ impl Render for PaneFlowApp {
         self.title_bar.update(cx, |tb, _| {
             tb.workspace_name = ws_name;
             tb.sidebar_visible = self.primary_sidebar_visible;
+            tb.rosetta_surface_open = self.rosetta_surface_expanded;
             tb.files_menu_open = self.title_bar_files_menu_open.is_some();
             tb.help_menu_open = self.title_bar_help_menu_open.is_some();
             tb.update_available = update_info;
@@ -1378,6 +1400,7 @@ impl Render for PaneFlowApp {
             .on_action(cx.listener(Self::handle_start_self_update))
             .on_action(cx.listener(Self::handle_dismiss_update))
             .on_action(cx.listener(Self::handle_open_agents_view))
+            .on_action(cx.listener(Self::handle_toggle_rosetta_surface))
             // US-011: title-bar `⋯` overflow menu for the current Agents thread.
             .on_action(cx.listener(Self::handle_open_agents_thread_menu))
             // EP-001 (cli-cockpit): Composer + broadcast groups.
@@ -1541,7 +1564,8 @@ impl Render for PaneFlowApp {
                                             })
                                             .p(px(5.))
                                     })
-                                    .child(main_content),
+                                    .child(main_content)
+                                    .when_some(rosetta_surface, |d, surface| d.child(surface)),
                             )
                             // Draw the panel contour. The right edge joins the
                             // contour only while a secondary sidebar is open,
@@ -1672,6 +1696,10 @@ impl Render for PaneFlowApp {
         }
         if self.launch_pad.is_some() && in_cli_mode {
             app_content = app_content.child(self.render_launch_pad(cx));
+        }
+        if self.rosetta_surface_expanded && std::mem::take(&mut self.rosetta_surface_pending_focus)
+        {
+            self.rosetta_surface_focus.focus(window, cx);
         }
         // EP-006 US-018: fleet-grep results overlay (same mode gate). The
         // deferred focus (the trigger event has no Window) lands here.

--- a/src-app/src/settings/tabs/ai_agent.rs
+++ b/src-app/src/settings/tabs/ai_agent.rs
@@ -53,6 +53,8 @@ impl PaneFlowApp {
         // independent injection fence. Defaults: unrestricted OFF, fence ON.
         let unrestricted = config.ai_unrestricted_enabled();
         let fence = config.ai_injection_fence_enabled();
+        let rosetta_enabled = config.rosetta_enabled();
+        let rosetta_show_passive = config.rosetta_show_passive_enabled();
 
         let buttons_card = setting_card(ui)
             .child(setting_row(
@@ -259,6 +261,36 @@ impl PaneFlowApp {
             .child(section_header(ui, "Permissions"))
             .child(permissions_card);
 
+        let mut rosetta_card = setting_card(ui).child(setting_row(
+            "row-rosetta-enabled",
+            "Rosetta",
+            "Show the in-app agent status card for supported Paneflow modes.",
+            None,
+            rosetta_enabled,
+            "rosetta_enabled",
+            ui,
+            cx,
+        ));
+        if rosetta_enabled {
+            rosetta_card = rosetta_card.child(hairline(ui)).child(setting_row(
+                "row-rosetta-passive",
+                "Show running agents",
+                "Allow passive running-only agent rows to appear as a compact Rosetta card. Turn off for urgent-only status.",
+                None,
+                rosetta_show_passive,
+                "rosetta_show_passive",
+                ui,
+                cx,
+            ));
+        }
+
+        let rosetta_section = div()
+            .mt(px(24.))
+            .flex()
+            .flex_col()
+            .child(section_header(ui, "Rosetta"))
+            .child(rosetta_card);
+
         // EP-003 US-009: AI access (free-access mode + injection fence). The
         // fence sub-toggle only appears once free-access is on: with the mode
         // off, surface.read is always fenced and there is nothing to relax.
@@ -321,6 +353,7 @@ impl PaneFlowApp {
             .flex_col()
             .child(buttons_section)
             .child(permissions_section)
+            .child(rosetta_section)
             .child(access_section)
             .child(div().h(px(180.)).flex_none())
     }

--- a/src-app/src/window_chrome/title_bar.rs
+++ b/src-app/src/window_chrome/title_bar.rs
@@ -12,6 +12,7 @@ pub struct TitleBar {
     should_move: bool,
     pub workspace_name: Option<String>,
     pub sidebar_visible: bool,
+    pub rosetta_surface_open: bool,
     pub files_menu_open: bool,
     pub help_menu_open: bool,
     pub ipc_state: crate::ipc::IpcState,
@@ -113,6 +114,7 @@ impl TitleBar {
             should_move: false,
             workspace_name: None,
             sidebar_visible: true,
+            rosetta_surface_open: false,
             files_menu_open: false,
             help_menu_open: false,
             ipc_state: crate::ipc::IpcState::Online,
@@ -130,6 +132,7 @@ impl TitleBar {
 pub enum TitleBarEvent {
     CloseRequested,
     ToggleSidebar,
+    ToggleRosettaSurface,
     ToggleFilesMenu(gpui::Point<gpui::Pixels>),
     ToggleHelpMenu(gpui::Point<gpui::Pixels>),
 }
@@ -238,12 +241,19 @@ impl Render for TitleBar {
             gpui::px(12.0)
         };
         let toggle_sidebar_handle = cx.entity().downgrade();
+        let toggle_rosetta_handle = cx.entity().downgrade();
         let toggle_files_menu_handle = cx.entity().downgrade();
         let toggle_help_menu_handle = cx.entity().downgrade();
         let sidebar_tooltip: gpui::SharedString = if self.sidebar_visible {
             "Hide sidebar"
         } else {
             "Show sidebar"
+        }
+        .into();
+        let rosetta_tooltip: gpui::SharedString = if self.rosetta_surface_open {
+            "Hide Rosetta"
+        } else {
+            "Show Rosetta"
         }
         .into();
         let mut brand = div()
@@ -289,6 +299,42 @@ impl Render for TitleBar {
                             .path("icons/sidebar.svg")
                             .text_color(ui.muted),
                     ),
+            )
+            .child(
+                div()
+                    .id("toggle-rosetta-surface")
+                    .flex_none()
+                    .w(px(24.))
+                    .h(px(24.))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded(px(5.))
+                    .cursor_pointer()
+                    .when(self.rosetta_surface_open, |d| {
+                        d.bg(crate::app::constants::sidebar_tab_active_background())
+                    })
+                    .hover(|s| s.bg(crate::app::constants::sidebar_tab_hover_background()))
+                    .tooltip(move |_window, cx| {
+                        let label = rosetta_tooltip.clone();
+                        cx.new(|_| crate::app::sidebar::SidebarTooltip { label })
+                            .into()
+                    })
+                    .on_mouse_down(MouseButton::Left, move |_, _, cx| {
+                        cx.stop_propagation();
+                        if let Some(entity) = toggle_rosetta_handle.upgrade() {
+                            entity.update(cx, |_this, cx| {
+                                cx.emit(TitleBarEvent::ToggleRosettaSurface);
+                            });
+                        }
+                    })
+                    .child(svg().size(px(14.)).path("icons/bell.svg").text_color(
+                        if self.rosetta_surface_open {
+                            ui.text
+                        } else {
+                            ui.muted
+                        },
+                    )),
             )
             .child(
                 div()

--- a/tasks/prd-paneflow-rosetta-2026-Q3-status.json
+++ b/tasks/prd-paneflow-rosetta-2026-Q3-status.json
@@ -1,0 +1,242 @@
+{
+  "prd": {
+    "file": "tasks/prd-paneflow-rosetta-2026-Q3.md",
+    "title": "Paneflow Rosetta - card interactive d'etat agents (2026-Q3)",
+    "created_at": "2026-06-27",
+    "status": "IN_PROGRESS"
+  },
+  "epics": [
+    {
+      "id": "EP-001",
+      "title": "Projection Rosetta de l'etat agent",
+      "status": "DONE",
+      "priority": "P0",
+      "stories_total": 3,
+      "stories_done": 3,
+      "reviewed_at": "2026-06-27"
+    },
+    {
+      "id": "EP-002",
+      "title": "Surface in-app top-center",
+      "status": "IN_REVIEW",
+      "priority": "P0",
+      "stories_total": 4,
+      "stories_done": 0
+    },
+    {
+      "id": "EP-003",
+      "title": "Navigation et handoff humain",
+      "status": "IN_REVIEW",
+      "priority": "P0",
+      "stories_total": 4,
+      "stories_done": 0
+    },
+    {
+      "id": "EP-004",
+      "title": "Securite, settings et readiness cross-platform",
+      "status": "IN_REVIEW",
+      "priority": "P0",
+      "stories_total": 3,
+      "stories_done": 0
+    }
+  ],
+  "stories": [
+    {
+      "id": "US-001",
+      "title": "Projection des sessions workspace",
+      "epic": "EP-001",
+      "status": "IN_REVIEW",
+      "priority": "P0",
+      "size": "M",
+      "blocked_by": [],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": "2026-06-27"
+    },
+    {
+      "id": "US-002",
+      "title": "Projection des threads Agents mode",
+      "epic": "EP-001",
+      "status": "IN_REVIEW",
+      "priority": "P0",
+      "size": "M",
+      "blocked_by": [
+        "US-001"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": "2026-06-27"
+    },
+    {
+      "id": "US-003",
+      "title": "Recent event history volatile",
+      "epic": "EP-001",
+      "status": "IN_REVIEW",
+      "priority": "P1",
+      "size": "S",
+      "blocked_by": [
+        "US-001"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": "2026-06-27"
+    },
+    {
+      "id": "US-004",
+      "title": "Card compacte top-center",
+      "epic": "EP-002",
+      "status": "IN_REVIEW",
+      "priority": "P0",
+      "size": "M",
+      "blocked_by": [
+        "US-001"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": null
+    },
+    {
+      "id": "US-005",
+      "title": "Expanded prioritized panel",
+      "epic": "EP-002",
+      "status": "IN_REVIEW",
+      "priority": "P0",
+      "size": "M",
+      "blocked_by": [
+        "US-004"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": null
+    },
+    {
+      "id": "US-006",
+      "title": "Input discipline and keyboard behavior",
+      "epic": "EP-002",
+      "status": "IN_REVIEW",
+      "priority": "P0",
+      "size": "M",
+      "blocked_by": [
+        "US-005"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": null
+    },
+    {
+      "id": "US-007",
+      "title": "Visual polish, status language and motion",
+      "epic": "EP-002",
+      "status": "IN_REVIEW",
+      "priority": "P1",
+      "size": "M",
+      "blocked_by": [
+        "US-004"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": null
+    },
+    {
+      "id": "US-008",
+      "title": "Focus exact workspace/pane/thread",
+      "epic": "EP-003",
+      "status": "IN_REVIEW",
+      "priority": "P0",
+      "size": "M",
+      "blocked_by": [
+        "US-001",
+        "US-005"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": null
+    },
+    {
+      "id": "US-009",
+      "title": "WaitingForInput handoff",
+      "epic": "EP-003",
+      "status": "IN_REVIEW",
+      "priority": "P0",
+      "size": "M",
+      "blocked_by": [
+        "US-008"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": null
+    },
+    {
+      "id": "US-010",
+      "title": "Typed action affordance framework",
+      "epic": "EP-003",
+      "status": "IN_REVIEW",
+      "priority": "P1",
+      "size": "M",
+      "blocked_by": [
+        "US-009"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": null
+    },
+    {
+      "id": "US-011",
+      "title": "Dismiss, snooze and noise rules",
+      "epic": "EP-003",
+      "status": "IN_REVIEW",
+      "priority": "P1",
+      "size": "S",
+      "blocked_by": [
+        "US-005"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": null
+    },
+    {
+      "id": "US-012",
+      "title": "Texte agent non fiable et trust boundary",
+      "epic": "EP-004",
+      "status": "IN_REVIEW",
+      "priority": "P0",
+      "size": "S",
+      "blocked_by": [
+        "US-005"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": null
+    },
+    {
+      "id": "US-013",
+      "title": "Settings and mode gating",
+      "epic": "EP-004",
+      "status": "IN_REVIEW",
+      "priority": "P1",
+      "size": "M",
+      "blocked_by": [
+        "US-004"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": null
+    },
+    {
+      "id": "US-014",
+      "title": "Regression coverage and visual QA runbook",
+      "epic": "EP-004",
+      "status": "IN_REVIEW",
+      "priority": "P1",
+      "size": "M",
+      "blocked_by": [
+        "US-004",
+        "US-008",
+        "US-012"
+      ],
+      "started_at": null,
+      "completed_at": "2026-06-27",
+      "reviewed_at": null
+    }
+  ]
+}

--- a/tasks/prd-paneflow-rosetta-2026-Q3.md
+++ b/tasks/prd-paneflow-rosetta-2026-Q3.md
@@ -1,0 +1,443 @@
+[PRD]
+# PRD: Paneflow Rosetta - card interactive d'etat agents (2026-Q3)
+
+## Changelog
+
+| Version | Date | Author | Summary |
+|---------|------|--------|---------|
+| 1.0 | 2026-06-27 | Arthur Jean | Draft initial - 4 epics / 14 stories. Definit Rosetta comme card in-app top-center qui decode l'etat des agents, priorise l'attention humaine et route vers la bonne pane/thread sans dependre d'une surface OS externe. |
+
+## Problem Statement
+
+Paneflow sait deja lancer, suivre et orchestrer plusieurs agents CLI, mais l'utilisateur n'a pas encore une surface centrale, persistante et actionnable qui lui dit quand son attention compte.
+
+1. **Le statut existe, mais il reste disperse.** Les etats agents vivent dans `Workspace::agent_sessions`, les dots de sidebar, l'Attention Queue, les notifications OS et les lignes Agents. Aucun endroit ne transforme toute cette verite en un signal top-level: "qui attend, pourquoi, depuis combien de temps, et ou cliquer".
+2. **Les notifications OS ne sont pas une base produit fiable.** Elles dependent des reglages systeme, du focus, des politiques Windows/macOS/Linux et ne peuvent pas porter une interaction riche cross-platform. Elles sont utiles comme fallback, pas comme experience principale.
+3. **Les agents paralleles changent le rythme du travail.** Quand 3-8 agents tournent, le probleme n'est plus "un agent a fini" mais "quelle intervention humaine est la plus importante maintenant". Sans priorisation, l'utilisateur retourne scanner les panes, perd le fil et rate des agents en attente.
+4. **Les alternatives du marche sont soit macOS-first, soit externes au terminal owner.** Vibe Island, Open Island, CodeIsland, Notchi et AgentNotch prouvent l'usage d'une surface top-center/notch pour agents, mais la plupart observent les terminaux depuis l'exterieur. Paneflow possede deja les panes, sessions, workspaces et cibles de focus.
+
+**Why now:** les workflows AI coding passent du chat mono-agent au travail multi-agents local. Les produits concurrents s'installent vite autour de la metaphore "agent island", mais la fenetre est encore ouverte pour une version Paneflow-native: cross-platform, liee aux panes reelles, sobre, actionnable et securisee. Rosetta doit devenir le signal top-level qui montre que Paneflow n'est pas seulement un multiplexer, mais un cockpit d'agents.
+
+## Overview
+
+Paneflow Rosetta est une card interactive top-center, directement integree a la fenetre Paneflow. Elle decode les signaux des agents en etats humains: running, needs input, stalled, done, failed. Elle reste compacte par defaut, s'etend quand une intervention est requise, et ramene l'utilisateur vers la pane ou le thread exact sans voler le focus.
+
+Rosetta reste volontairement in-app. Le coeur du produit doit etre fiable sur Windows, macOS, Linux X11 et Linux Wayland sans dependre d'une fenetre native separee. La promesse produit est une surface Paneflow integree, stable et actionnable, pas une surcouche OS.
+
+La decision structurante: Rosetta ne maintient pas une seconde verite agent. Elle derive ses rows depuis les sources existantes (`agent_sessions`, `ThreadStatus`, surface ids, waiting timestamps, last_result) et ne garde localement que l'etat UI: collapsed/expanded, selection, snooze/dismiss, recent history volatile.
+
+## Goals
+
+| Goal | Month-1 Target | Month-6 Target |
+|------|---------------|----------------|
+| Reduire les agents en attente rates | 100% des sessions `WaitingForInput` hookees visibles dans Rosetta en < 1 frame apres `cx.notify()` | >= 90% des sessions en attente sont rejointes via Rosetta ou Attention Queue plutot que scan manuel |
+| Rendre le statut multi-agent lisible | Card compacte affiche le bon etat dominant pour jusqu'a 32 sessions actives | Rosetta devient la surface par defaut de supervision dans les demos Paneflow multi-agents |
+| Fiabiliser le retour a la bonne pane | Clic sur une row resolue focus workspace + pane/thread exact dans 100% des cas ou `surface_id`/thread target existe | Fallback documente pour 100% des sessions non resolues, sans navigation vers une mauvaise pane |
+| Eviter le bruit | Les etats passifs (`Thinking`, `Finished`) ne provoquent pas d'expansion automatique hors seuils definis | Taux de dismiss/snooze manuel < 20% sur sessions dogfood de 1h |
+
+## Target Users
+
+### Dev orchestrateur Paneflow
+- **Role:** solo dev, indie maker ou power-user qui lance plusieurs agents CLI dans Paneflow.
+- **Behaviors:** travaille dans CLI/Agents mode, dispatch plusieurs prompts, laisse des agents tourner en arriere-plan, revient quand une permission ou une question bloque.
+- **Pain points:** doit regarder la sidebar, scanner les panes ou compter sur des notifications OS inconstantes pour savoir qui attend.
+- **Current workaround:** status sidebar, Attention Queue CLI, notifications OS, memoire personnelle de ce qui tourne.
+- **Success looks like:** savoir en un coup d'oeil quel agent attend, cliquer, arriver dans la bonne pane, repondre, repartir.
+
+### Utilisateur Agents mode
+- **Role:** utilisateur de la vue Agents qui gere des threads/projets Codex/Claude/OpenCode dans Paneflow.
+- **Behaviors:** navigue entre projets/chats, lit les diffs, surveille les agents sans rester dans chaque terminal.
+- **Pain points:** les dots compactes de la sidebar ne portent pas assez de contexte pour decider quoi ouvrir.
+- **Current workaround:** ouvrir chaque thread avec un indicateur non-idle, inspecter le terminal, revenir.
+- **Success looks like:** Rosetta explique "Codex needs input - paneflow-web" et ouvre directement le thread.
+
+### Utilisateur prudent / security-minded
+- **Role:** dev qui accepte l'autonomie agent mais ne veut pas qu'une UI d'agent puisse tromper ses actions.
+- **Behaviors:** lit les permissions, refuse les actions risquee, veut distinguer texte agent et controles Paneflow.
+- **Pain points:** les prompts compacts peuvent cacher le contexte d'une commande ou donner trop de pouvoir au texte genere par l'agent.
+- **Current workaround:** ouvrir la pane, relire le terminal complet, approuver manuellement.
+- **Success looks like:** Rosetta montre uniquement des controles Paneflow typés, garde le texte agent inert, et force l'ouverture de la pane quand le contexte est insuffisant.
+
+## Research Findings
+
+Key findings that informed this PRD:
+
+### Competitive Context
+- **Vibe Island:** benchmark payant macOS, card/notch native pour agents avec approvals, questions, plan review, sons et jump terminal. Rosetta differencie par integration Paneflow-native et cross-platform fiable.
+- **Open Island / open-vibe-island:** reference OSS qui reduit des hooks JSON en etat session puis overlay. Confirme le pattern event -> reducer -> status card.
+- **AgentsRoom Dynamic Island:** concurrent cross-platform avec fenetre flottante always-on-top. Confirme la demande, mais expose le risque de promettre une surface OS globale sur Wayland.
+- **CodeIsland / Notchi / AgentNotch:** prouvent que les utilisateurs attendent statut, tool calls, permissions, historique, usage/quota et signaux locaux. Leur faiblesse commune est la dependance a des hooks/adapters externes.
+- **Market gap:** une surface agent card qui possede les panes, le routage et la source de verite au lieu de surveiller depuis l'exterieur.
+
+### Best Practices Applied
+- Distinguer action-required et passive updates: `WaitingForInput`, `Errored`, `Stalled` ont priorite; `Thinking` et `Finished` n'ouvrent pas automatiquement le panel.
+- Eviter l'alert fatigue: Rosetta groupe, priorise, snooze et n'affiche pas chaque tool call dans la card compacte.
+- Ne pas voler le focus: la card signale et route; la saisie/reponse se fait dans une surface Paneflow focusable.
+- Texte agent non fiable: rendu inert, borne, jamais interprete comme un bouton ou une commande.
+- Placement stable: top-center dans la zone principale Paneflow, hors sidebar et hors titlebar OS.
+
+### Research Sources
+- [Vibe Island](https://vibeisland.app/)
+- [Open Island / open-vibe-island](https://github.com/Octane0411/open-vibe-island)
+- [AgentsRoom Dynamic Island](https://agentsroom.dev/features/dynamic-island)
+- [CodeIsland](https://github.com/wxtsky/CodeIsland)
+- [Notchi](https://github.com/sk-ruban/notchi)
+- [AgentNotch](https://github.com/AppGram/agentnotch)
+- [Microsoft notification UX guidance](https://learn.microsoft.com/en-us/windows/apps/develop/notifications/app-notifications/app-notifications-ux-guidance)
+- [NN/g notifications guidance](https://www.nngroup.com/articles/indicators-validations-notifications/)
+- [MDN ARIA live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions)
+- [Canonical Mir: Wayland window positioning](https://canonical.com/mir/docs/stable/explanation/window-positions-under-wayland/)
+- [OWASP AI Agent Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/AI_Agent_Security_Cheat_Sheet.html)
+- [Claude Code Agent View](https://code.claude.com/docs/en/agent-view)
+
+## Assumptions & Constraints
+
+### Assumptions (to validate)
+- Les utilisateurs preferent une card in-app fiable a une surface OS externe imparfaite sur Linux Wayland.
+- Une projection live derivee depuis `agent_sessions` et `ThreadStatus` suffit pour v1 sans store persistant dedie.
+- Le recent history volatile (session app courante) resout le probleme des `Finished` courts sans ajouter de migration disque.
+- Les actions directes `Approve/Deny` ne doivent apparaitre que lorsqu'un event type contient assez de metadata; sinon Rosetta doit router vers la pane.
+
+### Hard Constraints
+- Cross-platform obligatoire: Windows 10/11, macOS Intel/Apple Silicon, Linux X11/Wayland.
+- V1 in-app obligatoire; aucune dependance a un overlay OS global.
+- Aucun I/O, subprocess ou scan long dans le render path GPUI.
+- Pas de seconde source de verite agent: Rosetta derive depuis l'etat existant.
+- Texte agent affiche comme donnees non fiables: borne, inert, pas de Markdown actif, pas de controles generes par l'agent.
+- Ne pas casser l'Attention Queue, les notifications OS existantes, la sidebar ou Agents mode.
+
+## Quality Gates
+
+These commands must pass for every user story:
+- `cargo fmt --check` - formatage Rust canonique, obligatoire avant commit/push.
+- `cargo clippy --workspace -- -D warnings` - zero warning sur le workspace.
+- `cargo test --workspace` - tests unitaires et integration du workspace.
+
+For UI stories, additional gates:
+- Verification visuelle manuelle dans Paneflow a 1280x720, 1920x1080 et largeur <= 900px.
+- Verification manuelle dans CLI mode et Agents mode.
+- Si un OS cible ne peut pas etre verifie localement, noter explicitement l'OS non verifie dans le statut de story.
+
+## Epics & User Stories
+
+### EP-001: Projection Rosetta de l'etat agent
+
+Construire une projection unique et peu couteuse qui transforme les sources existantes en rows Rosetta priorisees.
+
+**Definition of Done:** Rosetta peut lister les sessions hookees, threads Agents et evenements recents sans store parallele ni I/O render-thread.
+
+#### US-001: Projection des sessions workspace
+**Description:** As a Paneflow user, I want Rosetta to derive live rows from workspace agent sessions so that the card reflects the same truth as panes and sidebar.
+
+**Priority:** P0
+**Size:** M (3 pts)
+**Dependencies:** None
+
+**Acceptance Criteria:**
+- [ ] Given multiple workspaces with `agent_sessions`, when Rosetta builds its projection, then each visible session includes `{tool, state, workspace_title, surface_id, message, waiting_secs, last_activity_secs, active_tool_name, last_result}` when available.
+- [ ] Given no active sessions, when projection runs, then it returns an empty list without rendering a stale card.
+- [ ] Given multiple states, when rows are ranked, then priority order is `Errored > WaitingForInput > Stalled > Thinking > Finished`.
+- [ ] Given a session with `surface_id = None`, when rendered later, then it is visible but not navigable.
+- [ ] Given projection runs during render, when measured with 32 sessions, then it performs no filesystem, process, network or IPC work.
+
+#### US-002: Projection des threads Agents mode
+**Description:** As an Agents mode user, I want Rosetta to include active agent threads so that the card covers both CLI panes and Agents threads.
+
+**Priority:** P0
+**Size:** M (3 pts)
+**Dependencies:** Blocked by US-001
+
+**Acceptance Criteria:**
+- [ ] Given an Agents thread with `ThreadStatus::WaitingForInput`, when Rosetta builds rows, then the row includes thread title, project/chat context and a focus target.
+- [ ] Given an Agents thread with `ThreadStatus::Failed`, when Rosetta builds rows, then it ranks above waiting/thinking rows.
+- [ ] Given `ThreadStatus::Idle`, when no recent completion event exists, then Rosetta omits the row from the active card.
+- [ ] Given a thread lacks a terminal view target, when clicked later, then Rosetta shows an unavailable target state instead of focusing a wrong pane.
+- [ ] Given `Stalled` is collapsed to `Thinking` in `ThreadStatus`, when Rosetta needs stalled precision, then it uses session-level data where available and never fabricates stalled state from idle threads.
+
+#### US-003: Recent event history volatile
+**Description:** As a user, I want recent done/error/wait transitions retained briefly so that short-lived agent changes are not missed.
+
+**Priority:** P1
+**Size:** S (2 pts)
+**Dependencies:** Blocked by US-001
+
+**Acceptance Criteria:**
+- [ ] Given a session transitions to `Finished`, when the active row auto-clears, then Rosetta retains a recent event row for 5 minutes or until a cap of 25 events is reached.
+- [ ] Given more than 25 recent events, when a new event is added, then the oldest event is dropped.
+- [ ] Given the app restarts, when Rosetta initializes, then recent history starts empty and no stale disk-backed event is shown.
+- [ ] Given an event contains agent text, when stored in history, then the text is capped at 512 chars and rendered inert.
+
+---
+
+### EP-002: Surface in-app top-center
+
+Livrer la card Rosetta visible, compacte et responsive dans la zone principale de Paneflow.
+
+**Definition of Done:** une card top-center s'affiche dans CLI et Agents mode, se collapse/expand correctement, respecte la titlebar/sidebar et reste lisible sur petites largeurs.
+
+#### US-004: Card compacte top-center
+**Description:** As a user, I want a compact top-center Rosetta card so that I can see the dominant agent status without scanning the sidebar.
+
+**Priority:** P0
+**Size:** M (3 pts)
+**Dependencies:** Blocked by US-001
+
+**Acceptance Criteria:**
+- [ ] Given at least one active or recent Rosetta row, when Paneflow renders, then the compact card appears top-center in the main content area, not inside the sidebar or OS titlebar.
+- [ ] Given no active or recent rows, when Paneflow renders, then Rosetta is hidden by default.
+- [ ] Given the app width is <= 900px, when rendered, then card width is <= viewport minus 32px and text ellipsizes without overlap.
+- [ ] Given the card is collapsed, when passive rows are only `Thinking`, then it shows a single-line summary without expanding automatically.
+- [ ] Given the render path runs repeatedly, when profiling, then Rosetta adds no animation layout shift to the terminal surface.
+
+#### US-005: Expanded prioritized panel
+**Description:** As a user, I want to expand Rosetta into a prioritized list so that I can decide which agent needs attention first.
+
+**Priority:** P0
+**Size:** M (3 pts)
+**Dependencies:** Blocked by US-004
+
+**Acceptance Criteria:**
+- [ ] Given the compact card is clicked, when rows exist, then an expanded panel lists sections for `Needs input`, `Failed`, `Stalled`, `Running`, and `Recent`.
+- [ ] Given multiple waiting agents, when expanded, then waiting rows are sorted by longest `waiting_since` first.
+- [ ] Given a row has a long message, when expanded, then the message is one or two inert ellipsized lines and never overlaps controls.
+- [ ] Given a row is not navigable, when expanded, then its action area shows `No pane` or `Unavailable` instead of an active focus button.
+- [ ] Given there are more than 8 rows, when expanded, then the panel scrolls inside a bounded height instead of growing over the full workspace.
+
+#### US-006: Input discipline and keyboard behavior
+**Description:** As a keyboard-heavy user, I want Rosetta to be interactive without stealing focus so that terminal input stays routed to the active terminal unless I explicitly activate Rosetta.
+
+**Priority:** P0
+**Size:** M (3 pts)
+**Dependencies:** Blocked by US-005
+
+**Acceptance Criteria:**
+- [ ] Given Rosetta is collapsed, when it appears due to a passive event, then it does not take keyboard focus.
+- [ ] Given Rosetta is expanded, when `Esc` is pressed, then it collapses and focus returns to the previous terminal/thread if it still exists.
+- [ ] Given Rosetta is expanded, when arrow keys move selection and `Enter` is pressed, then the selected navigable row focuses the target.
+- [ ] Given pointer events hit Rosetta, when clicking inside the card, then events are occluded and do not leak into the PTY behind it.
+- [ ] Given the target pane closes while Rosetta is open, when the user presses `Enter`, then no panic occurs and the row becomes unavailable on next render.
+
+#### US-007: Visual polish, status language and motion
+**Description:** As a user, I want Rosetta to match Paneflow's visual system so that it reads as product chrome rather than temporary toast chrome.
+
+**Priority:** P1
+**Size:** M (3 pts)
+**Dependencies:** Blocked by US-004
+
+**Acceptance Criteria:**
+- [ ] Given dark and light themes, when Rosetta renders, then it uses existing `UiColors` tokens and remains readable at contrast ratio >= 4.5:1 for text.
+- [ ] Given status changes, when the compact card updates, then motion duration is between 120ms and 180ms and respects reduced-motion settings if available.
+- [ ] Given the card is visible, when compared with sidebar cards, then it uses background alpha between 0.08 and 0.18, 8px max radius and font weight <= `MEDIUM` except for one section title.
+- [ ] Given status copy renders, when labels appear, then they use product language: `needs input`, `failed`, `stalled`, `running`, `done`, not raw wire strings.
+- [ ] Given narrow width, when the longest workspace title appears, then layout remains stable and truncates before buttons.
+
+---
+
+### EP-003: Navigation et handoff humain
+
+Transformer Rosetta en surface actionnable: elle signale, route vers le bon contexte, et ne prend des actions directes que quand les evenements sont typés et complets.
+
+**Definition of Done:** chaque row navigable peut ouvrir le bon workspace/pane/thread; les prompts humains sont traites comme handoff vers Paneflow; aucun bouton n'est genere depuis du texte agent.
+
+#### US-008: Focus exact workspace/pane/thread
+**Description:** As a user, I want clicking a Rosetta row to focus the exact agent target so that I do not scan panes manually.
+
+**Priority:** P0
+**Size:** M (3 pts)
+**Dependencies:** Blocked by US-001, US-005
+
+**Acceptance Criteria:**
+- [ ] Given a CLI row with live `surface_id`, when clicked, then Paneflow switches workspace, selects the pane tab and focuses the terminal.
+- [ ] Given an Agents row with a thread target, when clicked, then Paneflow switches to Agents mode and selects that project/chat thread.
+- [ ] Given the target no longer exists, when clicked, then Rosetta marks the row unavailable and does not change to an unrelated workspace.
+- [ ] Given the user clicks a passive `Finished` recent event, when no live target exists, then Rosetta opens the closest available workspace/project context or shows unavailable state.
+- [ ] Given a jump succeeds, when the card collapses, then the next keyboard navigation starts from the focused target.
+
+#### US-009: WaitingForInput handoff
+**Description:** As a user, I want Rosetta to handle agent questions by sending me to the right input surface so that I can respond without losing context.
+
+**Priority:** P0
+**Size:** M (3 pts)
+**Dependencies:** Blocked by US-008
+
+**Acceptance Criteria:**
+- [ ] Given a `WaitingForInput` row, when the primary action is clicked, then Paneflow focuses the target pane/thread and leaves text entry to the normal terminal/composer.
+- [ ] Given the waiting message is present, when displayed in Rosetta, then it is visibly separated from Paneflow action buttons.
+- [ ] Given the row is unresolved, when the user tries to respond, then Rosetta explains that the pane is unavailable and does not create a synthetic input target.
+- [ ] Given multiple waiting rows, when one is resolved by the user, then Rosetta updates priority and selects the next waiting row if expanded.
+- [ ] Given the agent clears waiting state before the user clicks, when clicked, then Rosetta refreshes and does not send stale input.
+
+#### US-010: Typed action affordance framework
+**Description:** As a cautious user, I want direct actions only for typed internal events so that agent text cannot manufacture approvals.
+
+**Priority:** P1
+**Size:** M (3 pts)
+**Dependencies:** Blocked by US-009
+
+**Acceptance Criteria:**
+- [ ] Given a row only has freeform `message`, when rendered, then Rosetta shows `Open`/`Reply` handoff actions, not `Approve`/`Deny`.
+- [ ] Given a future typed approval event includes command, cwd, tool, risk level and action id, when rendered, then Rosetta may show direct `Approve`/`Deny` controls generated from typed fields only.
+- [ ] Given an approval command exceeds 160 chars, when rendered compactly, then Rosetta truncates display but requires opening the pane or expanded detail before approval.
+- [ ] Given a high-risk typed action is marked destructive/network/credential/publish, when rendered, then direct approval is disabled in compact mode.
+- [ ] Given agent text includes button-like wording, when rendered, then it remains inert text and cannot bind actions.
+
+#### US-011: Dismiss, snooze and noise rules
+**Description:** As a user, I want to suppress low-value Rosetta noise without hiding urgent agent needs so that the card keeps a low interruption rate.
+
+**Priority:** P1
+**Size:** S (2 pts)
+**Dependencies:** Blocked by US-005
+
+**Acceptance Criteria:**
+- [ ] Given a `Finished` recent row, when dismissed, then it disappears from recent history and does not remove the real session state.
+- [ ] Given a `WaitingForInput` row, when snoozed, then the compact card reduces urgency for 10 minutes but the row remains visible in expanded view.
+- [ ] Given an `Errored` row, when dismissed, then it remains visible in expanded history until the underlying session is cleared or a new run replaces it.
+- [ ] Given passive `Thinking` rows only, when user disables passive display, then Rosetta hides until waiting/error/stall/done history exists.
+- [ ] Given snooze expires, when the row still waits, then Rosetta restores urgent compact state.
+
+---
+
+### EP-004: Securite, settings et readiness cross-platform
+
+Durcir Rosetta comme surface de confiance integree a Paneflow: texte non fiable, settings explicites et QA cross-platform.
+
+**Definition of Done:** Rosetta est securisee contre le texte agent trompeur, configurable, testee, et documentee comme surface in-app cross-platform.
+
+#### US-012: Texte agent non fiable et trust boundary
+**Description:** As a security-minded user, I want Rosetta to treat agent text as untrusted so that the card cannot become a phishing or command-injection surface.
+
+**Priority:** P0
+**Size:** S (2 pts)
+**Dependencies:** Blocked by US-005
+
+**Acceptance Criteria:**
+- [ ] Given agent text contains Markdown, ANSI, links or control-looking text, when rendered in Rosetta, then it is inert plain text.
+- [ ] Given agent text exceeds 512 chars, when stored or displayed, then it is capped and ellipsized.
+- [ ] Given bidi/control characters are present, when displayed, then existing sanitization behavior is preserved or matched.
+- [ ] Given Paneflow controls render next to agent text, when visually inspected, then controls are separated by layout, color and copy so text cannot impersonate a button.
+- [ ] Given a future direct action exists, when its metadata is incomplete, then Rosetta refuses direct action and falls back to `Open`.
+
+#### US-013: Settings and mode gating
+**Description:** As a user, I want Rosetta display behavior to be configurable so that I can reduce interruptions during focused work.
+
+**Priority:** P1
+**Size:** M (3 pts)
+**Dependencies:** Blocked by US-004
+
+**Acceptance Criteria:**
+- [ ] Given no config key exists, when Paneflow starts after Rosetta ships, then Rosetta is enabled for urgent states and passive rows are collapsed by default.
+- [ ] Given the user disables Rosetta, when Paneflow renders, then no Rosetta card appears but sidebar/Attention Queue/OS notification behavior remains unchanged.
+- [ ] Given the user changes passive display or snooze defaults, when config is saved, then settings persist across restart.
+- [ ] Given config is invalid, when loaded, then Paneflow falls back to urgent-only defaults and does not panic.
+- [ ] Given the app is in Review mode, when Rosetta is enabled, then the PRD implementation either explicitly supports it or documents why it is mode-gated off.
+
+#### US-014: Regression coverage and visual QA runbook
+**Description:** As an implementer, I want automated and manual verification for Rosetta so that the card does not regress panes, focus or layout.
+
+**Priority:** P1
+**Size:** M (3 pts)
+**Dependencies:** Blocked by US-004, US-008, US-012
+
+**Acceptance Criteria:**
+- [ ] Given projection helpers, when unit tests run, then empty, waiting, errored, stalled, multi-agent and unresolved-surface cases are covered.
+- [ ] Given keyboard routing, when tests or manual verification run, then `Esc`, arrow navigation and `Enter` behavior are checked.
+- [ ] Given the UI runbook, when followed, then it covers CLI mode, Agents mode, narrow width, multiple workspaces and closed-target fallback.
+- [ ] Given Linux Wayland is not locally available, when validating, then the runbook records the unverified platform instead of claiming full manual coverage.
+- [ ] Given unrelated dirty files exist, when implementing Rosetta stories, then only Rosetta-scoped files are staged and status JSON is updated per story.
+
+## Functional Requirements
+
+- FR-01: The system must render Rosetta in-app, top-center, inside the Paneflow window.
+- FR-02: The system must derive Rosetta rows from existing Paneflow agent/session/thread state, not from a parallel lifecycle store.
+- FR-03: The system must rank rows by user salience: error, waiting, stalled, running, done/recent.
+- FR-04: The system must support collapsed and expanded states.
+- FR-05: The system must focus the exact workspace/pane/thread when a navigable row is activated.
+- FR-06: The system must display unresolved rows as visible but non-navigable.
+- FR-07: The system must keep agent-provided text inert and bounded.
+- FR-08: The system must not show direct approval actions from freeform agent text.
+- FR-09: The system must remain integrated inside the Paneflow window and must not rely on OS notifications or a separate OS-level window for core behavior.
+- FR-10: The system must preserve existing Attention Queue, sidebar and OS notification behavior.
+
+## Non-Functional Requirements
+
+- **Performance:** Rosetta projection must add < 2 ms P95 render-path CPU cost with 32 active sessions on a dev build machine; no filesystem/process/network/IPC work in render.
+- **Layout:** Collapsed card width must be <= min(420px, viewport width - 32px); expanded card height must be <= 70% viewport height.
+- **Accessibility:** Expanded card must support keyboard navigation with `Esc`, arrows and `Enter`; no passive event may steal keyboard focus.
+- **Security:** Agent text displayed by Rosetta must be capped at 512 chars, rendered as inert plain text and separated from Paneflow controls.
+- **Reliability:** A navigable row must never focus a different agent target when its original target disappears; fallback must be unavailable state or closest explicit context.
+- **Cross-platform:** V1 must compile and behave in-app on Windows, macOS and Linux.
+
+## Edge Cases & Error States
+
+Systematic coverage of unhappy paths. Evidence shows earlier defect discovery significantly reduces cost (Boehm 1981, NIST 2002).
+
+| # | Scenario | Trigger | Expected Behavior | User Message |
+|---|----------|---------|-------------------|--------------|
+| 1 | Empty state | No active or recent rows | Card hidden by default | - |
+| 2 | Multiple urgent agents | 3 sessions waiting | Compact card shows count; expanded panel sorts longest wait first | "3 agents need input" |
+| 3 | Unresolved surface | `surface_id = None` | Row visible, action disabled | "No pane" |
+| 4 | Target closes after render | Pane/thread removed before click | No panic; row becomes unavailable | "Target unavailable" |
+| 5 | Long agent message | Message > 512 chars | Cap and ellipsize inert text | Truncated text |
+| 6 | Agent text impersonates UI | Message says "Click Approve" | Render as plain text, no generated action | Plain text only |
+| 7 | Small window | Width <= 900px | Card shrinks, truncates labels, no overlap | - |
+| 8 | Mode switch while expanded | User switches CLI -> Agents/Review | Card collapses or rebinds to supported mode without stale focus | - |
+| 9 | Finished auto-clear | `Finished` session removed after delay | Recent history preserves event for 5 min | "Done" |
+
+## Risks & Mitigations
+
+| # | Risk | Probability | Impact | Mitigation |
+|---|------|------------|--------|------------|
+| 1 | Rosetta becomes noisy and users ignore it | Med | High | Salience ranking, passive collapse, snooze/dismiss, no tool-call spam in compact card |
+| 2 | State drift from panes/sidebar | Med | High | Derived projection only; no parallel lifecycle store |
+| 3 | Focus/routing opens wrong pane | Low | High | Require explicit `surface_id`/thread target; unresolved rows are non-navigable |
+| 4 | Agent text tricks user into unsafe action | Med | High | Inert text, typed action metadata only, direct approvals disabled for freeform messages |
+| 5 | Top-center card clashes with titlebar/sidebar or terminal | Med | Med | Main-content placement, bounded width/height, visual QA at multiple sizes |
+| 6 | Scope drifts into OS-level notification platform | Med | Med | Keep Rosetta in-app; reject OS-global overlay work in this PRD |
+
+## Non-Goals
+
+Explicit boundaries - what this version does NOT include:
+
+- No standalone paid Rosetta app in v1. Rosetta ships as a Paneflow-native feature first.
+- No OS-global notification surface or separate Rosetta app in this PRD. Rosetta remains integrated into the Paneflow window.
+- No sound design or audio alerts in v1.
+- No direct command approval generated from freeform agent text.
+- No replacement or removal of existing OS notifications, sidebar status or Attention Queue.
+- No persistent on-disk event history in v1.
+
+## Files NOT to Modify
+
+- `src-app/src/app/ipc_handler.rs` - avoid broad lifecycle rewrites; Rosetta should consume existing state and only touch handlers if a story explicitly needs a small hook.
+- `src-app/src/app/event_handlers.rs` - avoid changing stale PID/stalled semantics while building UI.
+- `src-app/src/ipc_events.rs` - do not change event-bus protocol for Rosetta v1.
+- `src-app/src/ai_types.rs` - do not change `AgentState` semantics; helper projections are acceptable if scoped.
+- `src-app/src/project/mod.rs` - do not alter `ThreadStatus` semantics unless a story explicitly validates the change.
+- `src-app/src/terminal/view.rs` - do not place Rosetta as per-terminal UI.
+
+## Technical Considerations
+
+Frame as questions for engineering input - not mandates:
+
+- **Architecture:** add a focused `src-app/src/app/rosetta.rs` module and a small render hook in `PaneFlowApp::render`. Engineering to confirm whether state fields belong directly in `PaneFlowApp` or a nested `RosettaState`.
+- **Projection:** derive rows from `Workspace::agent_sessions`, Agents thread status and recent volatile events. Engineering to confirm if existing `workspace_agent_status` can be reused or if Rosetta needs a richer projection type.
+- **Rendering:** use GPUI `deferred` absolute positioning, top-center within main content, and mouse occlusion. Rosetta should render inside the existing Paneflow window.
+- **Focus:** reuse existing surface routing (`find_pane_by_surface_id`, workspace focus helpers, Agents target selection). Engineering to confirm exact APIs per mode.
+- **Settings:** extend config only after US-013; default should keep urgent Rosetta enabled and passive rows collapsed.
+- **Testing:** pure projection/ranking helpers should be unit-tested; GPUI visual behavior needs manual verification.
+
+## Success Metrics
+
+| Metric | Baseline (current) | Target | Timeframe | How Measured |
+|--------|-------------------|--------|-----------|-------------|
+| Waiting sessions visible centrally | 0% central card coverage | 100% hook-backed `WaitingForInput` rows visible in Rosetta | Month-1 | Manual dogfood + projection tests |
+| Exact target jump success | Attention Queue covers CLI waiting only; no Rosetta | 100% success when `surface_id` or Agents target exists | Month-1 | Manual QA runbook |
+| Passive noise | N/A (new feature) | Passive-only Rosetta does not auto-expand | Month-1 | Manual QA + tests for priority policy |
+| Render overhead | N/A (new feature) | < 2 ms P95 projection/render overhead at 32 sessions | Month-1 | Local instrumentation or debug timing |
+| Cross-platform v1 reliability | OS notifications inconsistent on Windows/dev setups | In-app Rosetta verified or explicitly recorded on Windows/macOS/Linux | Month-6 | QA matrix in story status |
+
+## Open Questions
+
+- Should Rosetta be visible in Review mode, or only CLI + Agents for v1? Owner: product/engineering before US-013.
+- What exact typed event schema should unlock direct `Approve/Deny` later? Owner: engineering before US-010 implementation.
+- Should recent history become persistent after v1? Owner: product after dogfood metrics.
+[/PRD]


### PR DESCRIPTION
## Summary

- Add the in-app Rosetta agent status surface for CLI and Agents mode.
- Derive Rosetta rows from existing workspace sessions, Agents threads, and volatile recent events.
- Add config/schema settings, UI controls, routing behavior, notification context, tests, PRD status, and QA runbook.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

Manual cross-platform visual QA remains documented in `docs/rosetta-qa-runbook.md`.